### PR TITLE
ci: add Docker build and publish GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,22 @@ jobs:
 
       - name: Install and build
         uses: ./.github/actions/install-and-build
+
+  docker-build:
+    runs-on: [prod-gen2-dind-runner]
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: ./.github/actions/pnpm-setup
+
+      - name: Install and build
+        uses: ./.github/actions/install-and-build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker images
+        run: pnpm docker:build
+        shell: bash

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,25 @@
+name: Docker Publish
+on:
+  push:
+    branches:
+      - main
+      - develop # TODO: remove — temporary for testing, main only long-term
+jobs:
+  docker-push:
+    runs-on: [prod-gen2-dind-runner]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: ./.github/actions/pnpm-setup
+
+      - name: Install and build
+        uses: ./.github/actions/install-and-build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Push Docker images
+        run: pnpm docker:push
+        shell: bash

--- a/apps/pi-led-api/package.json
+++ b/apps/pi-led-api/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "docker:build": "abctl docker build",
-    "docker:publish": "abctl docker publish",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "dev": "tsc-watch -p tsconfig.build.json --onSuccess \"node ./dist/index.js\"",


### PR DESCRIPTION
Add docker-build job to build.yml (runs on PRs via dind runner) and new docker-publish.yml workflow to push images on merge to main. Temporarily includes develop branch for initial testing.