### PR TITLE
ci: Docker workflows, gluetun-sync v0.1.0

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(docker compose *)",
       "Bash(docker run *)",
       "Bash(pnpm docker:build)",
-      "Bash(pnpm docker:push *)"
+      "Bash(pnpm docker:push *)",
+      "Bash(pnpm changeset *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,7 @@
       "Bash(docker compose *)",
       "Bash(docker run *)",
       "Bash(pnpm docker:build)",
-      "Bash(pnpm docker:push *)",
+      "Bash(pnpm docker:publish *)",
       "Bash(pnpm changeset *)",
       "Skill(dump)",
       "Skill(caveman:caveman-commit)",

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,10 @@
       "Bash(pnpm docker:push *)",
       "Bash(pnpm changeset *)",
       "Skill(dump)",
-      "Skill(caveman:caveman-commit)"
+      "Skill(caveman:caveman-commit)",
+      "Bash(gh pr *)",
+      "Bash(git fetch *)",
+      "Bash(git stash *)"
     ]
   }
 }

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,5 +20,5 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Push Docker images
-        run: pnpm docker:push
+        run: pnpm docker:publish
         shell: bash

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop # TODO: remove — temporary for testing, main only long-term
 jobs:
   docker-push:
     runs-on: [prod-gen2-dind-runner]

--- a/apps/gluetun-sync/CHANGELOG.md
+++ b/apps/gluetun-sync/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @abbottland/gluetun-sync
 
+## 0.1.0
+
+### Minor Changes
+
+- Update API clients for gluetun and qBittorrent breaking changes
+
 ## 0.0.10
 
 ### Patch Changes

--- a/apps/gluetun-sync/package.json
+++ b/apps/gluetun-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abbottland/gluetun-sync",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "docker:build": "abctl docker build",

--- a/docs/dev-env-abctl.md
+++ b/docs/dev-env-abctl.md
@@ -23,7 +23,7 @@ For example, take a look at `apps/gluetun-sync/package.json`. In the `package.js
 ```json
   "scripts": {
     "docker:build": "abctl docker build",
-    "docker:push": "abctl docker push"
+    "docker:publish": "abctl docker publish"
   },
   "devDependencies": {
     "@abbottland/abctl": "workspace:*"

--- a/docs/dev-guide-publication-to-docker.md
+++ b/docs/dev-guide-publication-to-docker.md
@@ -17,10 +17,10 @@ Be sure to run a docker build by following steps for the [Docker build process](
 
 ### Step 3 - Push all docker images to remote
 
-This command will run `docker:push` across all packages, and will avoid overwriting any existing version in a remote repository.
+This command will run `docker:publish` across all packages, and will avoid overwriting any existing version in a remote repository.
 
 ```sh
-pnpm docker:push
+pnpm docker:publish
 ```
 
 > [!NOTE]
@@ -38,13 +38,13 @@ Be sure to list `abctl` as a `devDependency`
 }
 ```
 
-### 2 - Set docker:push script
+### 2 - Set docker:publish script
 
-Each package needing docker support should have a script named `docker:push`. This can just be a call to the `abctl` CLI
+Each package needing docker support should have a script named `docker:publish`. This can just be a call to the `abctl` CLI
 
 ```json
 "scripts": {
-    "docker:push": "abctl docker push"
+    "docker:publish": "abctl docker publish"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "turbo run build",
     "build:abctl": "turbo run build --filter=@abbottland/abctl",
     "docker:build": "turbo run docker:build",
-    "docker:push": "turbo run docker:push",
+    "docker:publish": "turbo run docker:publish",
     "env:generate": "turbo run env:generate",
     "clean": "turbo run clean",
     "dev": "turbo run dev",

--- a/turbo.json
+++ b/turbo.json
@@ -48,7 +48,7 @@
       "cache": false,
       "dependsOn": ["^build"]
     },
-    "docker:push": {
+    "docker:publish": {
       "dependsOn": ["^docker:build"],
       "cache": false
     },


### PR DESCRIPTION
## Summary

- Add Docker build and publish GitHub Actions workflows
- Restrict docker-publish workflow to `main` branch only
- Bump `gluetun-sync` to v0.1.0 (API client updates for gluetun and qBittorrent breaking changes)
- Remove docker scripts from `pi-led-api` superseded by CI workflows

## Test plan

- [ ] Verify Docker build workflow triggers on PR
- [ ] Verify Docker publish workflow only triggers on merge to `main`
- [ ] Confirm `gluetun-sync` v0.1.0 image builds and publishes correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)