### PR TITLE
chore(release): bump blog, diagram-maker, fui-components versions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -26,7 +26,9 @@
       "Bash(git fetch *)",
       "Bash(git stash *)",
       "Bash(pnpm --filter @abbottland/abctl build)",
-      "Bash(docker pull *)"
+      "Bash(docker pull *)",
+      "Bash(kubectl logs *)",
+      "Bash(kubectl get pvc *)"
     ]
   }
 }

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abbottland/blog",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/diagram-maker/package.json
+++ b/apps/diagram-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abbottland/diagram-maker",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 4021",

--- a/packages/fui-components/package.json
+++ b/packages/fui-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abbottland/fui-components",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "scripts": {
     "docker:build": "abctl docker build",


### PR DESCRIPTION
## Summary

- `blog`: 0.2.5 → 0.3.0 (minor — new landing section animations and terminal feature)
- `diagram-maker`: 0.0.2 → 0.0.3 (patch)
- `fui-components`: 0.4.4 → 0.4.5 (patch)

## Test plan

- [ ] CI passes (build, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)