### PR TITLE
feat(abctl): add buildx registry cache support

### DIFF
--- a/apps/blog/abctl.yml
+++ b/apps/blog/abctl.yml
@@ -3,3 +3,4 @@ build:
   dockerfile: Dockerfile
   context: .
   platform: linux/amd64
+  buildCache: harbor.local.abbottland.io/build-cache

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abbottland/blog",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/diagram-maker/abctl.yml
+++ b/apps/diagram-maker/abctl.yml
@@ -3,3 +3,4 @@ build:
   dockerfile: Dockerfile
   context: .
   platform: linux/amd64
+  buildCache: harbor.local.abbottland.io/build-cache

--- a/apps/diagram-maker/package.json
+++ b/apps/diagram-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abbottland/diagram-maker",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 4021",

--- a/apps/gluetun-sync/abctl.yml
+++ b/apps/gluetun-sync/abctl.yml
@@ -1,4 +1,6 @@
 buildPreset: pnpm-turbo-docker-build
+build:
+  buildCache: harbor.local.abbottland.io/build-cache
 secrets:
   generateEnv: true
   envFile: .env

--- a/apps/gluetun-sync/package.json
+++ b/apps/gluetun-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abbottland/gluetun-sync",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "docker:build": "abctl docker build",

--- a/apps/pi-led-api/abctl.yml
+++ b/apps/pi-led-api/abctl.yml
@@ -1,3 +1,4 @@
 buildPreset: pnpm-turbo-docker-build
 build:
   platform: linux/arm64,linux/amd64
+  buildCache: harbor.local.abbottland.io/build-cache

--- a/apps/pi-led-api/package.json
+++ b/apps/pi-led-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abbottland/pi-led-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/abctl/package.json
+++ b/packages/abctl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abbottland/abctl",
   "description": "Abbottland control CLI for common repository tasks",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/abctl/src/build-logic/build-presets.ts
+++ b/packages/abctl/src/build-logic/build-presets.ts
@@ -19,6 +19,7 @@ export const getBuildConfigFromPresetName = (presetName: string): DockerBuildCon
         target: '',
         dockerfile: './Dockerfile',
         platform: 'linux/amd64',
+        buildCache: '',
       }
     case 'pnpm-turbo-docker-build':
       return {
@@ -31,6 +32,7 @@ export const getBuildConfigFromPresetName = (presetName: string): DockerBuildCon
         target: '',
         dockerfile: '../../docker/pnpm-turbo.Dockerfile',
         platform: 'linux/amd64',
+        buildCache: '',
       }
     default:
       throw new Error(`Unknown build preset: ${presetName}`)

--- a/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.ts
+++ b/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.ts
@@ -6,7 +6,7 @@ export const makeBuildSettings = (
   dockerBuildConfig: DockerBuildConfig,
   projectMetadata: ProjectMetadata,
 ): DockerBuildSettings => {
-  const {baseImage, context, dockerfile, load, push, ...rest} = dockerBuildConfig
+  const {baseImage, context, dockerfile, load, push, buildCache, ...rest} = dockerBuildConfig
 
   const buildArgs: Record<string, string> = {}
 
@@ -28,6 +28,7 @@ export const makeBuildSettings = (
     buildArgs,
     load: load === 'true',
     push: push === 'true',
+    ...(buildCache ? {cacheRef: buildCache} : {}),
     ...rest,
   }
 }

--- a/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.unit.test.ts
+++ b/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.unit.test.ts
@@ -20,29 +20,43 @@ describe('@abbottland/abctl/docker-build-settings-builder makeBuildSettings', ()
     projectName: 'one-cool-app',
     version: '99.0.1',
   }
-  const sut = makeBuildSettings(image, dockerBuildConfig, projectMetadata)
 
-  // TODO: Add tests for the build settings
-  it('should set image', () => {
-    expect(sut.image).toBe(image)
+  describe('without buildCache config', () => {
+    const sut = makeBuildSettings(image, dockerBuildConfig, projectMetadata)
+
+    it('should set image', () => {
+      expect(sut.image).toBe(image)
+    })
+    it('should set context', () => {
+      expect(sut.context).toBe(dockerBuildConfig.context)
+    })
+    it('should set dockerfile', () => {
+      expect(sut.dockerfile).toBe(dockerBuildConfig.dockerfile)
+    })
+    it('should set platform', () => {
+      expect(sut.platform).toBe(dockerBuildConfig.platform)
+    })
+    it('should set target', () => {
+      expect(sut.target).toBe(dockerBuildConfig.target)
+    })
+    it('should set build args', () => {
+      expect(sut.buildArgs).toEqual({
+        BASE_IMAGE: dockerBuildConfig.baseImage,
+        PROJECT_DIR: `${projectMetadata.parentDirName}/`,
+        PROJECT: projectMetadata.projectName,
+      })
+    })
+    it('should not set cacheRef', () => {
+      expect(sut.cacheRef).toBeUndefined()
+    })
   })
-  it('should set context', () => {
-    expect(sut.context).toBe(dockerBuildConfig.context)
-  })
-  it('should set dockerfile', () => {
-    expect(sut.dockerfile).toBe(dockerBuildConfig.dockerfile)
-  })
-  it('should set platform', () => {
-    expect(sut.platform).toBe(dockerBuildConfig.platform)
-  })
-  it('should set target', () => {
-    expect(sut.target).toBe(dockerBuildConfig.target)
-  })
-  it('should set build args', () => {
-    expect(sut.buildArgs).toEqual({
-      BASE_IMAGE: dockerBuildConfig.baseImage,
-      PROJECT_DIR: `${projectMetadata.parentDirName}/`,
-      PROJECT: projectMetadata.projectName,
+
+  describe('with buildCache config', () => {
+    const cacheRegistry = 'harbor.local.abbottland.io/build-cache'
+    const sut = makeBuildSettings(image, {...dockerBuildConfig, buildCache: cacheRegistry}, projectMetadata)
+
+    it('should set cacheRef from buildCache config', () => {
+      expect(sut.cacheRef).toBe(cacheRegistry)
     })
   })
 })

--- a/packages/abctl/src/config/abctl-config.ts
+++ b/packages/abctl/src/config/abctl-config.ts
@@ -108,4 +108,7 @@ export class DockerBuildConfig {
 
   /** Should --push be set during the build process? */
   push = 'false'
+
+  /** Registry URL used for buildx --cache-from/--cache-to (e.g. harbor.local.abbottland.io/build-cache) */
+  buildCache = ''
 }

--- a/packages/abctl/src/docker-cli/docker-build-settings.ts
+++ b/packages/abctl/src/docker-cli/docker-build-settings.ts
@@ -7,4 +7,5 @@ export type DockerBuildSettings = {
   load?: boolean
   platform?: string
   target?: string
+  cacheRef?: string
 }

--- a/packages/abctl/src/docker-cli/docker-commands.ts
+++ b/packages/abctl/src/docker-cli/docker-commands.ts
@@ -49,7 +49,7 @@ export const checkRemoteImageExists = async (imageWithTag: string): Promise<bool
 
 export async function dockerBuild(settings: DockerBuildSettings) {
   try {
-    const {image, context, buildArgs = {}, dockerfile, push, load, platform, target} = settings
+    const {image, context, buildArgs = {}, dockerfile, push, load, platform, target, cacheRef} = settings
     const command = 'docker'
     const args = ['buildx', 'build']
 
@@ -63,6 +63,13 @@ export async function dockerBuild(settings: DockerBuildSettings) {
 
     if (platform) {
       args.push('--platform', platform)
+    }
+
+    if (cacheRef) {
+      const repoName = image.split('/').pop()!.split(':')[0]
+      const fullCacheRef = `${cacheRef}/${repoName}`
+      args.push('--cache-from', `type=registry,ref=${fullCacheRef}`)
+      args.push('--cache-to', `type=registry,ref=${fullCacheRef},mode=max`)
     }
 
     if (push) {

--- a/packages/fui-components/abctl.yml
+++ b/packages/fui-components/abctl.yml
@@ -2,3 +2,4 @@ build:
   dockerfile: Dockerfile
   context: .
   platform: linux/amd64
+  buildCache: harbor.local.abbottland.io/build-cache

--- a/packages/fui-components/package.json
+++ b/packages/fui-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abbottland/fui-components",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "docker:build": "abctl docker build",


### PR DESCRIPTION
## Summary

- Add `buildCache` field to `DockerBuildConfig` in abctl — when set, injects `--cache-from type=registry,ref=<buildCache>/<repo>` and `--cache-to type=registry,ref=<buildCache>/<repo>,mode=max` into the `docker buildx build` command
- All `abctl.yml` files updated with `buildCache: harbor.local.abbottland.io/build-cache`
- Repo name is automatically derived from the image tag, so each project gets its own cache repository (e.g. `build-cache/gluetun-sync`)
- Patch version bump for all affected packages: `abctl` → `0.0.1`, `blog` → `0.4.2`, `diagram-maker` → `0.0.5`, `gluetun-sync` → `0.1.1`, `pi-led-api` → `0.1.1`, `fui-components` → `0.5.1`

## Test plan

- [x] `pnpm test:unit` passes in `packages/abctl`
- [x] `pnpm docker:build` in `apps/gluetun-sync` shows `--cache-from`/`--cache-to` args in command output
- [x] Second build confirms all steps `CACHED` via `importing cache manifest from harbor.local.abbottland.io/build-cache/gluetun-sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)