### PR TITLE
feat(harbor-cleanup): add Harbor registry cleanup service

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  IMAGE_REPO: harbor.local.abbottland.io/library/blog
-
 jobs:
   docker-publish:
     runs-on: [prod-gen2-dind-runner]
@@ -32,9 +29,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Retag as production image
+      - name: Retag as production images
         run: bash ./scripts/docker-retag-prod.sh
         env:
-          IMAGE_REPO: ${{ env.IMAGE_REPO }}
           COMMIT_SHA: ${{ github.sha }}
           RUN_NUMBER: ${{ github.run_number }}

--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -5,6 +5,9 @@ import createMDX from '@next/mdx';
 /** @type {NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  env: {
+    IMAGE_TAG: process.env.IMAGE_TAG ?? 'dev',
+  },
   // Configure `pageExtensions` to include markdown and MDX files
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
   // Optionally, add any other Next.js config below

--- a/apps/harbor-cleanup/abctl.yml
+++ b/apps/harbor-cleanup/abctl.yml
@@ -14,6 +14,6 @@ secrets:
       - secretName: harbor.local.abbottland.io - admin
         secretKey: password
         envVarName: HARBOR_PASSWORD
-      - secretName: GitHub Personal Access Token
-        secretKey: token
+      - secretName: Github PAT
+        secretKey: github_pat
         envVarName: GITHUB_TOKEN

--- a/apps/harbor-cleanup/abctl.yml
+++ b/apps/harbor-cleanup/abctl.yml
@@ -1,0 +1,19 @@
+buildPreset: pnpm-turbo-docker-build
+build:
+  buildCache: harbor.local.abbottland.io/build-cache
+secrets:
+  generateEnv: true
+  envFile: .env
+  envSampleFile: sample.env
+  onePassword:
+    vault: Homelab
+    items:
+      - secretName: harbor.local.abbottland.io - admin
+        secretKey: username
+        envVarName: HARBOR_USERNAME
+      - secretName: harbor.local.abbottland.io - admin
+        secretKey: password
+        envVarName: HARBOR_PASSWORD
+      - secretName: GitHub Personal Access Token
+        secretKey: token
+        envVarName: GITHUB_TOKEN

--- a/apps/harbor-cleanup/eslint.config.mjs
+++ b/apps/harbor-cleanup/eslint.config.mjs
@@ -1,0 +1,2 @@
+import server from '@abbottland/eslint-config/server.js';
+export default server;

--- a/apps/harbor-cleanup/jest.config.ts
+++ b/apps/harbor-cleanup/jest.config.ts
@@ -1,0 +1,21 @@
+/** @jest-config-loader ts-node -P tsconfig.test.json */
+
+import type { Config } from 'jest';
+import {
+  unitTestPreset,
+  integrationTestPreset,
+  jestReporters,
+} from '@abbottland/jest-presets';
+
+const config: Config = {
+  projects: [
+    unitTestPreset,
+    {
+      ...integrationTestPreset,
+      setupFilesAfterEnv: ['<rootDir>/tests/jest.integration.setup.ts'],
+    },
+  ],
+  reporters: jestReporters,
+};
+
+export default config;

--- a/apps/harbor-cleanup/package.json
+++ b/apps/harbor-cleanup/package.json
@@ -12,8 +12,7 @@
     "lint": "tsc --noEmit && eslint \"src/**/*.ts*\" --max-warnings 0",
     "start": "node ./dist/index.js",
     "test": "pnpm run test:unit && pnpm run test:int",
-    "test:unit": "jest --config jest.config.ts --selectProjects unit",
-    "test:int": "jest --config jest.config.ts --selectProjects integration"
+    "test:unit": "jest --config jest.config.ts --selectProjects unit"
   },
   "dependencies": {
     "@abbottland/express": "workspace:*",

--- a/apps/harbor-cleanup/package.json
+++ b/apps/harbor-cleanup/package.json
@@ -20,7 +20,9 @@
     "@abbottland/logger": "workspace:*",
     "@abbottland/yaml-config": "workspace:*",
     "@kubernetes/client-node": "^0.22.3",
+    "cronstrue": "^2.59.0",
     "express": "catalog:",
+    "node-cron": "^3.0.3",
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
@@ -31,6 +33,7 @@
     "@types/express": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
+    "@types/node-cron": "^3.0.11",
     "@types/supertest": "^6.0.3",
     "dotenv": "^16.6.1",
     "jest": "catalog:",

--- a/apps/harbor-cleanup/package.json
+++ b/apps/harbor-cleanup/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@abbottland/harbor-cleanup",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "docker:build": "abctl docker build",
+    "docker:publish": "abctl docker publish",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "dev": "tsc-watch -p tsconfig.build.json --onSuccess \"node ./dist/index.js\"",
+    "env:generate": "abctl secrets generate-env",
+    "lint": "tsc --noEmit && eslint \"src/**/*.ts*\" --max-warnings 0",
+    "start": "node ./dist/index.js",
+    "test": "pnpm run test:unit && pnpm run test:int",
+    "test:unit": "jest --config jest.config.ts --selectProjects unit",
+    "test:int": "jest --config jest.config.ts --selectProjects integration"
+  },
+  "dependencies": {
+    "@abbottland/express": "workspace:*",
+    "@abbottland/logger": "workspace:*",
+    "@abbottland/yaml-config": "workspace:*",
+    "@kubernetes/client-node": "^0.22.3",
+    "express": "catalog:",
+    "reflect-metadata": "^0.2.2"
+  },
+  "devDependencies": {
+    "@abbottland/abctl": "workspace:*",
+    "@abbottland/eslint-config": "workspace:*",
+    "@abbottland/jest-presets": "workspace:*",
+    "@abbottland/typescript-config": "workspace:*",
+    "@types/express": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/supertest": "^6.0.3",
+    "dotenv": "^16.6.1",
+    "jest": "catalog:",
+    "jest-junit": "^16.0.0",
+    "supertest": "^7.1.4",
+    "ts-node": "catalog:",
+    "tsc-watch": "^6.3.1",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/harbor-cleanup/sample.env
+++ b/apps/harbor-cleanup/sample.env
@@ -10,7 +10,7 @@ GITHUB_OWNER=pbabbott
 GITHUB_REPO=home-web-apps
 
 # Comma-separated list of Harbor repositories (under library/) to clean up
-CLEANUP_REPOSITORIES=blog
+CLEANUP_REPOSITORIES=blog,diagram-maker,fui-components,gluetun-sync,harbor-cleanup
 
 # Number of most-recent production images to retain per repository
 PROD_KEEP_COUNT=5

--- a/apps/harbor-cleanup/sample.env
+++ b/apps/harbor-cleanup/sample.env
@@ -14,3 +14,7 @@ CLEANUP_REPOSITORIES=blog
 
 # Number of most-recent production images to retain per repository
 PROD_KEEP_COUNT=5
+
+# Cron schedule for automatic cleanup (default: 3am daily)
+CLEANUP_CRON_EXPRESSION=0 3 * * *
+TZ=America/Chicago

--- a/apps/harbor-cleanup/sample.env
+++ b/apps/harbor-cleanup/sample.env
@@ -1,0 +1,16 @@
+PORT=4030
+SHOW_CONFIG=true
+
+HARBOR_HOST=harbor.local.abbottland.io
+HARBOR_USERNAME=secret_value_goes_here
+HARBOR_PASSWORD=secret_value_goes_here
+
+GITHUB_TOKEN=secret_value_goes_here
+GITHUB_OWNER=pbabbott
+GITHUB_REPO=home-web-apps
+
+# Comma-separated list of Harbor repositories (under library/) to clean up
+CLEANUP_REPOSITORIES=blog
+
+# Number of most-recent production images to retain per repository
+PROD_KEEP_COUNT=5

--- a/apps/harbor-cleanup/src/api/github/githubClient.ts
+++ b/apps/harbor-cleanup/src/api/github/githubClient.ts
@@ -1,0 +1,85 @@
+export type PullRequestState = 'open' | 'closed';
+
+export interface PullRequest {
+  number: number;
+  state: PullRequestState;
+  headSha: string;
+}
+
+export class GitHubClient {
+  private readonly baseUrl = 'https://api.github.com';
+  private readonly authHeader: string;
+  private readonly repoPath: string;
+
+  constructor(token: string, owner: string, repo: string) {
+    this.authHeader = `Bearer ${token}`;
+    this.repoPath = `${owner}/${repo}`;
+  }
+
+  async getPullRequest(prNumber: number): Promise<PullRequest | null> {
+    const url = `${this.baseUrl}/repos/${this.repoPath}/pulls/${prNumber}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: this.authHeader,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (res.status === 404) return null;
+    if (!res.ok)
+      throw new Error(
+        `GitHub getPullRequest failed: ${res.status} ${await res.text()}`,
+      );
+
+    const data = (await res.json()) as {
+      number: number;
+      state: string;
+      head: { sha: string };
+    };
+    return {
+      number: data.number,
+      state: data.state as PullRequestState,
+      headSha: data.head.sha,
+    };
+  }
+
+  async listOpenPullRequests(): Promise<PullRequest[]> {
+    const results: PullRequest[] = [];
+    let page = 1;
+
+    while (true) {
+      const url = `${this.baseUrl}/repos/${this.repoPath}/pulls?state=open&per_page=100&page=${page}`;
+      const res = await fetch(url, {
+        headers: {
+          Authorization: this.authHeader,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+
+      if (!res.ok)
+        throw new Error(
+          `GitHub listOpenPullRequests failed: ${res.status} ${await res.text()}`,
+        );
+
+      const data = (await res.json()) as Array<{
+        number: number;
+        state: string;
+        head: { sha: string };
+      }>;
+      results.push(
+        ...data.map((pr) => ({
+          number: pr.number,
+          state: pr.state as PullRequestState,
+          headSha: pr.head.sha,
+        })),
+      );
+
+      if (data.length < 100) break;
+      page++;
+    }
+
+    return results;
+  }
+}

--- a/apps/harbor-cleanup/src/api/github/githubClient.ts
+++ b/apps/harbor-cleanup/src/api/github/githubClient.ts
@@ -1,3 +1,5 @@
+import { RequestThrottler } from '../throttle.js';
+
 export type PullRequestState = 'open' | 'closed';
 
 export interface PullRequest {
@@ -10,6 +12,7 @@ export class GitHubClient {
   private readonly baseUrl = 'https://api.github.com';
   private readonly authHeader: string;
   private readonly repoPath: string;
+  private readonly throttler = new RequestThrottler(200);
 
   constructor(token: string, owner: string, repo: string) {
     this.authHeader = `Bearer ${token}`;
@@ -18,6 +21,7 @@ export class GitHubClient {
 
   async getPullRequest(prNumber: number): Promise<PullRequest | null> {
     const url = `${this.baseUrl}/repos/${this.repoPath}/pulls/${prNumber}`;
+    await this.throttler.wait();
     const res = await fetch(url, {
       headers: {
         Authorization: this.authHeader,
@@ -50,6 +54,7 @@ export class GitHubClient {
 
     while (true) {
       const url = `${this.baseUrl}/repos/${this.repoPath}/pulls?state=open&per_page=100&page=${page}`;
+      await this.throttler.wait();
       const res = await fetch(url, {
         headers: {
           Authorization: this.authHeader,

--- a/apps/harbor-cleanup/src/api/harbor/harborClient.ts
+++ b/apps/harbor-cleanup/src/api/harbor/harborClient.ts
@@ -1,3 +1,5 @@
+import { RequestThrottler } from '../throttle.js';
+
 export interface HarborTag {
   name: string;
 }
@@ -10,6 +12,7 @@ export interface HarborArtifact {
 export class HarborClient {
   private readonly baseUrl: string;
   private readonly authHeader: string;
+  private readonly throttler = new RequestThrottler(200);
 
   constructor(host: string, username: string, password: string) {
     this.baseUrl = `https://${host}/api/v2.0`;
@@ -27,6 +30,7 @@ export class HarborClient {
 
     while (true) {
       const url = `${this.baseUrl}/projects/${project}/repositories/${encodeURIComponent(repository)}/artifacts?with_tag=true&page_size=${pageSize}&page=${page}`;
+      await this.throttler.wait();
       const res = await fetch(url, {
         headers: { Authorization: this.authHeader, Accept: 'application/json' },
       });
@@ -54,6 +58,7 @@ export class HarborClient {
     tag: string,
   ): Promise<void> {
     const url = `${this.baseUrl}/projects/${project}/repositories/${encodeURIComponent(repository)}/artifacts/${encodeURIComponent(digest)}/tags/${encodeURIComponent(tag)}`;
+    await this.throttler.wait();
     const res = await fetch(url, {
       method: 'DELETE',
       headers: { Authorization: this.authHeader },

--- a/apps/harbor-cleanup/src/api/harbor/harborClient.ts
+++ b/apps/harbor-cleanup/src/api/harbor/harborClient.ts
@@ -1,0 +1,68 @@
+export interface HarborTag {
+  name: string;
+}
+
+export interface HarborArtifact {
+  digest: string;
+  tags: HarborTag[];
+}
+
+export class HarborClient {
+  private readonly baseUrl: string;
+  private readonly authHeader: string;
+
+  constructor(host: string, username: string, password: string) {
+    this.baseUrl = `https://${host}/api/v2.0`;
+    this.authHeader =
+      'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+  }
+
+  async listArtifacts(
+    project: string,
+    repository: string,
+  ): Promise<HarborArtifact[]> {
+    const results: HarborArtifact[] = [];
+    let page = 1;
+    const pageSize = 100;
+
+    while (true) {
+      const url = `${this.baseUrl}/projects/${project}/repositories/${encodeURIComponent(repository)}/artifacts?with_tag=true&page_size=${pageSize}&page=${page}`;
+      const res = await fetch(url, {
+        headers: { Authorization: this.authHeader, Accept: 'application/json' },
+      });
+
+      if (!res.ok) {
+        throw new Error(
+          `Harbor listArtifacts failed: ${res.status} ${await res.text()}`,
+        );
+      }
+
+      const page_results = (await res.json()) as HarborArtifact[];
+      results.push(...page_results);
+
+      if (page_results.length < pageSize) break;
+      page++;
+    }
+
+    return results;
+  }
+
+  async deleteTag(
+    project: string,
+    repository: string,
+    digest: string,
+    tag: string,
+  ): Promise<void> {
+    const url = `${this.baseUrl}/projects/${project}/repositories/${encodeURIComponent(repository)}/artifacts/${encodeURIComponent(digest)}/tags/${encodeURIComponent(tag)}`;
+    const res = await fetch(url, {
+      method: 'DELETE',
+      headers: { Authorization: this.authHeader },
+    });
+
+    if (!res.ok && res.status !== 404) {
+      throw new Error(
+        `Harbor deleteTag failed for ${tag}: ${res.status} ${await res.text()}`,
+      );
+    }
+  }
+}

--- a/apps/harbor-cleanup/src/api/kubernetes/kubernetesClient.ts
+++ b/apps/harbor-cleanup/src/api/kubernetes/kubernetesClient.ts
@@ -1,0 +1,55 @@
+import { KubeConfig, CoreV1Api } from '@kubernetes/client-node';
+
+export class KubernetesClient {
+  private coreApi: CoreV1Api | null = null;
+
+  constructor() {
+    try {
+      const kc = new KubeConfig();
+      kc.loadFromDefault();
+      this.coreApi = kc.makeApiClient(CoreV1Api);
+      console.log('[k8s] Client initialised from default kubeconfig');
+    } catch (err) {
+      console.warn(
+        '[k8s] Could not load kubeconfig — deployed-image protection will be skipped:',
+        err,
+      );
+    }
+  }
+
+  async getDeployedImageTags(registryHost: string): Promise<Set<string>> {
+    if (!this.coreApi) return new Set();
+
+    try {
+      const res = await this.coreApi.listPodForAllNamespaces();
+      const tags = new Set<string>();
+
+      for (const pod of res.body.items) {
+        const containers = [
+          ...(pod.spec?.containers ?? []),
+          ...(pod.spec?.initContainers ?? []),
+        ];
+        for (const container of containers) {
+          const image = container.image ?? '';
+          if (!image.startsWith(registryHost)) continue;
+
+          const colonIdx = image.lastIndexOf(':');
+          if (colonIdx !== -1) {
+            tags.add(image.substring(colonIdx + 1));
+          }
+        }
+      }
+
+      console.log(
+        `[k8s] Found ${tags.size} distinct image tag(s) currently deployed`,
+      );
+      return tags;
+    } catch (err) {
+      console.warn(
+        '[k8s] Failed to list pods — deployed-image protection will be skipped:',
+        err,
+      );
+      return new Set();
+    }
+  }
+}

--- a/apps/harbor-cleanup/src/api/kubernetes/kubernetesClient.ts
+++ b/apps/harbor-cleanup/src/api/kubernetes/kubernetesClient.ts
@@ -1,7 +1,9 @@
 import { KubeConfig, CoreV1Api } from '@kubernetes/client-node';
+import { RequestThrottler } from '../throttle.js';
 
 export class KubernetesClient {
   private coreApi: CoreV1Api | null = null;
+  private readonly throttler = new RequestThrottler(200);
 
   constructor() {
     try {
@@ -21,6 +23,7 @@ export class KubernetesClient {
     if (!this.coreApi) return new Set();
 
     try {
+      await this.throttler.wait();
       const res = await this.coreApi.listPodForAllNamespaces();
       const tags = new Set<string>();
 

--- a/apps/harbor-cleanup/src/api/throttle.ts
+++ b/apps/harbor-cleanup/src/api/throttle.ts
@@ -1,0 +1,15 @@
+export class RequestThrottler {
+  private lastRequestTime = 0;
+
+  constructor(private readonly intervalMs: number) {}
+
+  async wait(): Promise<void> {
+    const elapsed = Date.now() - this.lastRequestTime;
+    if (elapsed < this.intervalMs) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, this.intervalMs - elapsed),
+      );
+    }
+    this.lastRequestTime = Date.now();
+  }
+}

--- a/apps/harbor-cleanup/src/config.ts
+++ b/apps/harbor-cleanup/src/config.ts
@@ -38,7 +38,8 @@ export class ApplicationConfig {
   showConfig: boolean = false;
 
   @EnvironmentVariable()
-  cleanupRepositories: string = 'blog';
+  cleanupRepositories: string =
+    'blog,diagram-maker,fui-components,gluetun-sync,harbor-cleanup';
 
   @EnvironmentVariable({ variableType: EnvironmentVariableType.NUMBER })
   prodKeepCount: number = 5;

--- a/apps/harbor-cleanup/src/config.ts
+++ b/apps/harbor-cleanup/src/config.ts
@@ -1,4 +1,5 @@
 import * as dotenv from 'dotenv';
+import cron from 'node-cron';
 import {
   ConfigSection,
   EnvironmentVariable,
@@ -42,6 +43,15 @@ export class ApplicationConfig {
   @EnvironmentVariable({ variableType: EnvironmentVariableType.NUMBER })
   prodKeepCount: number = 5;
 
+  @EnvironmentVariable()
+  cronExpression: string = '0 3 * * *';
+
+  @EnvironmentVariable({
+    variableName: 'TZ',
+    variableType: EnvironmentVariableType.STRING,
+  })
+  TZ: string = 'America/Chicago';
+
   @ConfigSection({ sectionPrefix: 'HARBOR' })
   harbor = new HarborConfig();
 
@@ -74,6 +84,10 @@ export const validateConfig = () => {
   if (!config.gitHub.owner) errors.push('GITHUB_OWNER');
   if (!config.gitHub.repo) errors.push('GITHUB_REPO');
   if (!config.cleanupRepositories) errors.push('CLEANUP_REPOSITORIES');
+  if (!config.cronExpression) errors.push('CLEANUP_CRON_EXPRESSION');
+  if (!cron.validate(config.cronExpression))
+    errors.push('CLEANUP_CRON_EXPRESSION is not a valid cron expression');
+  if (!config.TZ) errors.push('TZ');
 
   if (errors.length) {
     errors.forEach((x) => console.error('Missing config variable: ' + x));

--- a/apps/harbor-cleanup/src/config.ts
+++ b/apps/harbor-cleanup/src/config.ts
@@ -1,0 +1,82 @@
+import * as dotenv from 'dotenv';
+import {
+  ConfigSection,
+  EnvironmentVariable,
+  EnvironmentVariableType,
+  loadConfig,
+} from '@abbottland/yaml-config';
+import { errorExit } from './process';
+
+export class HarborConfig {
+  @EnvironmentVariable()
+  host: string = '';
+
+  @EnvironmentVariable()
+  username: string = '';
+
+  @EnvironmentVariable()
+  password: string = '';
+}
+
+export class GitHubConfig {
+  @EnvironmentVariable()
+  token: string = '';
+
+  @EnvironmentVariable()
+  owner: string = '';
+
+  @EnvironmentVariable()
+  repo: string = '';
+}
+
+export class ApplicationConfig {
+  @EnvironmentVariable({ variableType: EnvironmentVariableType.NUMBER })
+  port: number = 4030;
+
+  @EnvironmentVariable({ variableType: EnvironmentVariableType.BOOLEAN })
+  showConfig: boolean = false;
+
+  @EnvironmentVariable()
+  cleanupRepositories: string = 'blog';
+
+  @EnvironmentVariable({ variableType: EnvironmentVariableType.NUMBER })
+  prodKeepCount: number = 5;
+
+  @ConfigSection({ sectionPrefix: 'HARBOR' })
+  harbor = new HarborConfig();
+
+  @ConfigSection({ sectionPrefix: 'GITHUB' })
+  gitHub = new GitHubConfig();
+}
+
+export let config: ApplicationConfig;
+
+export const initConfig = async () => {
+  dotenv.config();
+  const defaultConfig = new ApplicationConfig();
+  config = await loadConfig(defaultConfig);
+  if (config.showConfig) {
+    console.log('config', {
+      ...config,
+      harbor: { ...config.harbor, password: '***' },
+      gitHub: { ...config.gitHub, token: '***' },
+    });
+  }
+};
+
+export const validateConfig = () => {
+  const errors: string[] = [];
+
+  if (!config.harbor.host) errors.push('HARBOR_HOST');
+  if (!config.harbor.username) errors.push('HARBOR_USERNAME');
+  if (!config.harbor.password) errors.push('HARBOR_PASSWORD');
+  if (!config.gitHub.token) errors.push('GITHUB_TOKEN');
+  if (!config.gitHub.owner) errors.push('GITHUB_OWNER');
+  if (!config.gitHub.repo) errors.push('GITHUB_REPO');
+  if (!config.cleanupRepositories) errors.push('CLEANUP_REPOSITORIES');
+
+  if (errors.length) {
+    errors.forEach((x) => console.error('Missing config variable: ' + x));
+    errorExit();
+  }
+};

--- a/apps/harbor-cleanup/src/controllers/cleanup.ts
+++ b/apps/harbor-cleanup/src/controllers/cleanup.ts
@@ -1,15 +1,19 @@
 import type { Request, Response } from 'express';
 import { runCleanup } from '../services/cleanupService';
+import { logRunFailure, logRunStart, logRunSuccess } from '../data';
 
 export const doCleanup = async (_req: Request, res: Response) => {
   console.log('[cleanup] POST /cleanup triggered');
+  logRunStart('API');
   try {
     const result = await runCleanup();
+    logRunSuccess(result);
     const status = result.totalErrors > 0 ? 207 : 200;
     res.status(status).json(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error('[cleanup] Unhandled error:', message);
+    logRunFailure(message);
     res.status(500).json({ error: message });
   }
 };

--- a/apps/harbor-cleanup/src/controllers/cleanup.ts
+++ b/apps/harbor-cleanup/src/controllers/cleanup.ts
@@ -1,0 +1,15 @@
+import type { Request, Response } from 'express';
+import { runCleanup } from '../services/cleanupService';
+
+export const doCleanup = async (_req: Request, res: Response) => {
+  console.log('[cleanup] POST /cleanup triggered');
+  try {
+    const result = await runCleanup();
+    const status = result.totalErrors > 0 ? 207 : 200;
+    res.status(status).json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[cleanup] Unhandled error:', message);
+    res.status(500).json({ error: message });
+  }
+};

--- a/apps/harbor-cleanup/src/controllers/metrics.ts
+++ b/apps/harbor-cleanup/src/controllers/metrics.ts
@@ -1,0 +1,77 @@
+import type { Request, Response } from 'express';
+import { getStatusRecord } from '../data';
+import { config } from '../config';
+
+const toSeconds = (d?: Date): number | undefined =>
+  d ? d.getTime() / 1000 : undefined;
+
+const gauge = (
+  name: string,
+  help: string,
+  value: number | undefined,
+  labels?: Record<string, string>,
+): string => {
+  if (value === undefined) return '';
+  const labelStr = labels
+    ? '{' +
+      Object.entries(labels)
+        .map(
+          ([k, v]) =>
+            `${k}="${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`,
+        )
+        .join(',') +
+      '}'
+    : '';
+  return `# HELP ${name} ${help}\n# TYPE ${name} gauge\n${name}${labelStr} ${value}\n`;
+};
+
+export const getMetrics = (_req: Request, res: Response) => {
+  const s = getStatusRecord();
+
+  const output = [
+    gauge('harbor_cleanup_info', 'Static configuration info', 1, {
+      cron_expression: config.cronExpression,
+      timezone: config.TZ,
+    }),
+    gauge(
+      'harbor_cleanup_last_run_start_timestamp_seconds',
+      'Unix timestamp of last cleanup run start',
+      toSeconds(s.lastRunStart),
+    ),
+    gauge(
+      'harbor_cleanup_last_run_end_timestamp_seconds',
+      'Unix timestamp of last cleanup run end',
+      toSeconds(s.lastRunEnd),
+    ),
+    gauge(
+      'harbor_cleanup_last_success_timestamp_seconds',
+      'Unix timestamp of last successful cleanup run',
+      toSeconds(s.lastSuccess),
+    ),
+    gauge(
+      'harbor_cleanup_last_failure_timestamp_seconds',
+      'Unix timestamp of last failed cleanup run',
+      toSeconds(s.lastFailure),
+    ),
+    gauge(
+      'harbor_cleanup_last_run_duration_ms',
+      'Duration of last cleanup run in milliseconds',
+      s.lastResult?.durationMs,
+    ),
+    gauge(
+      'harbor_cleanup_last_run_total_deleted',
+      'Total tags deleted in last cleanup run',
+      s.lastResult?.totalDeleted,
+    ),
+    gauge(
+      'harbor_cleanup_last_run_total_errors',
+      'Total errors in last cleanup run',
+      s.lastResult?.totalErrors,
+    ),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+  res.status(200).send(output);
+};

--- a/apps/harbor-cleanup/src/controllers/status.ts
+++ b/apps/harbor-cleanup/src/controllers/status.ts
@@ -1,0 +1,13 @@
+import type { Request, Response } from 'express';
+import { getStatusRecord } from '../data';
+import { config } from '../config';
+import cronstrue from 'cronstrue';
+
+export const getStatus = (_req: Request, res: Response) => {
+  res.status(200).json({
+    schedule: cronstrue.toString(config.cronExpression),
+    cronExpression: config.cronExpression,
+    timezone: config.TZ,
+    ...getStatusRecord(),
+  });
+};

--- a/apps/harbor-cleanup/src/cron.ts
+++ b/apps/harbor-cleanup/src/cron.ts
@@ -1,0 +1,35 @@
+import cron from 'node-cron';
+import cronstrue from 'cronstrue';
+import { runCleanup } from './services/cleanupService';
+import { config } from './config';
+import { logRunFailure, logRunStart, logRunSuccess } from './data';
+
+export const startCron = () => {
+  const cronExpression = config.cronExpression;
+  const friendlyExpression = cronstrue.toString(cronExpression);
+  console.log(
+    `[cron] Cleanup scheduled: ${friendlyExpression} (TZ: ${config.TZ})`,
+  );
+
+  cron.schedule(cronExpression, cronJob, {
+    scheduled: true,
+    timezone: config.TZ,
+  });
+};
+
+export const cronJob = async () => {
+  const now = new Date();
+  console.log(`[cron] Starting cleanup run at ${now.toLocaleString('en-US')}`);
+  logRunStart('CRON');
+  try {
+    const result = await runCleanup();
+    logRunSuccess(result);
+    console.log(
+      `[cron] Cleanup complete. Deleted ${result.totalDeleted}, errors ${result.totalErrors}`,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[cron] Cleanup failed: ${message}`);
+    logRunFailure(message);
+  }
+};

--- a/apps/harbor-cleanup/src/data/index.ts
+++ b/apps/harbor-cleanup/src/data/index.ts
@@ -1,0 +1,34 @@
+import type { CleanupResult } from '../services/cleanupService';
+
+export type CleanupCaller = 'CRON' | 'API';
+
+export type StatusRecord = {
+  lastRunStart?: Date;
+  lastRunEnd?: Date;
+  lastSuccess?: Date;
+  lastFailure?: Date;
+  lastFailureMessage?: string;
+  lastCaller?: CleanupCaller;
+  lastResult?: CleanupResult;
+};
+
+const store: StatusRecord = {};
+
+export const getStatusRecord = (): StatusRecord => store;
+
+export const logRunStart = (caller: CleanupCaller) => {
+  store.lastRunStart = new Date();
+  store.lastCaller = caller;
+};
+
+export const logRunSuccess = (result: CleanupResult) => {
+  store.lastRunEnd = new Date();
+  store.lastSuccess = new Date();
+  store.lastResult = result;
+};
+
+export const logRunFailure = (message: string) => {
+  store.lastRunEnd = new Date();
+  store.lastFailure = new Date();
+  store.lastFailureMessage = message;
+};

--- a/apps/harbor-cleanup/src/index.ts
+++ b/apps/harbor-cleanup/src/index.ts
@@ -1,0 +1,11 @@
+import 'reflect-metadata';
+import { initConfig, validateConfig } from './config';
+import { startServer } from './server';
+
+const start = async () => {
+  await initConfig();
+  validateConfig();
+  startServer();
+};
+
+start();

--- a/apps/harbor-cleanup/src/index.ts
+++ b/apps/harbor-cleanup/src/index.ts
@@ -1,11 +1,16 @@
 import 'reflect-metadata';
 import { initConfig, validateConfig } from './config';
 import { startServer } from './server';
+import { cronJob, startCron } from './cron';
 
 const start = async () => {
   await initConfig();
   validateConfig();
+
+  startCron();
   startServer();
+
+  setTimeout(cronJob, 1000 * 10);
 };
 
 start();

--- a/apps/harbor-cleanup/src/process.ts
+++ b/apps/harbor-cleanup/src/process.ts
@@ -1,0 +1,4 @@
+export const errorExit = () => {
+  console.error('Program Terminated.');
+  process.exit(1);
+};

--- a/apps/harbor-cleanup/src/server.ts
+++ b/apps/harbor-cleanup/src/server.ts
@@ -4,6 +4,7 @@ import {
   configureHealthRoute,
 } from '@abbottland/express';
 import { doCleanup } from './controllers/cleanup';
+import { getStatus } from './controllers/status';
 import { config } from './config';
 
 export const createServer = (): Express => {
@@ -12,7 +13,7 @@ export const createServer = (): Express => {
   configureBaseServerMiddleware(app);
   configureHealthRoute(app);
 
-  app.post('/cleanup', doCleanup);
+  app.post('/cleanup', doCleanup).get('/status', getStatus);
 
   return app;
 };

--- a/apps/harbor-cleanup/src/server.ts
+++ b/apps/harbor-cleanup/src/server.ts
@@ -1,0 +1,26 @@
+import express, { type Express } from 'express';
+import {
+  configureBaseServerMiddleware,
+  configureHealthRoute,
+} from '@abbottland/express';
+import { doCleanup } from './controllers/cleanup';
+import { config } from './config';
+
+export const createServer = (): Express => {
+  const app = express();
+
+  configureBaseServerMiddleware(app);
+  configureHealthRoute(app);
+
+  app.post('/cleanup', doCleanup);
+
+  return app;
+};
+
+export const startServer = () => {
+  const port = config.port;
+  const server = createServer();
+  server.listen(port, () =>
+    console.log(`harbor-cleanup running on port ${port}`),
+  );
+};

--- a/apps/harbor-cleanup/src/server.ts
+++ b/apps/harbor-cleanup/src/server.ts
@@ -5,6 +5,7 @@ import {
 } from '@abbottland/express';
 import { doCleanup } from './controllers/cleanup';
 import { getStatus } from './controllers/status';
+import { getMetrics } from './controllers/metrics';
 import { config } from './config';
 
 export const createServer = (): Express => {
@@ -13,7 +14,10 @@ export const createServer = (): Express => {
   configureBaseServerMiddleware(app);
   configureHealthRoute(app);
 
-  app.post('/cleanup', doCleanup).get('/status', getStatus);
+  app
+    .post('/cleanup', doCleanup)
+    .get('/status', getStatus)
+    .get('/metrics', getMetrics);
 
   return app;
 };

--- a/apps/harbor-cleanup/src/services/cleanupService.ts
+++ b/apps/harbor-cleanup/src/services/cleanupService.ts
@@ -1,0 +1,231 @@
+import { HarborClient } from '../api/harbor/harborClient';
+import { GitHubClient } from '../api/github/githubClient';
+import { KubernetesClient } from '../api/kubernetes/kubernetesClient';
+import { catalogTags, sortProdTagsDesc } from './tagParser';
+import type { PrTag } from './tagParser';
+import { config } from '../config';
+
+export interface RepositoryCleanupResult {
+  repository: string;
+  deleted: string[];
+  kept: string[];
+  skippedDeployed: string[];
+  errors: string[];
+  durationMs: number;
+}
+
+export interface CleanupResult {
+  repositories: RepositoryCleanupResult[];
+  totalDeleted: number;
+  totalErrors: number;
+  durationMs: number;
+}
+
+const log = (repo: string, msg: string) =>
+  console.log(`[cleanup][${repo}] ${msg}`);
+
+async function cleanupRepository(
+  repo: string,
+  harbor: HarborClient,
+  github: GitHubClient,
+  deployedTags: Set<string>,
+): Promise<RepositoryCleanupResult> {
+  const start = Date.now();
+  const result: RepositoryCleanupResult = {
+    repository: repo,
+    deleted: [],
+    kept: [],
+    skippedDeployed: [],
+    errors: [],
+    durationMs: 0,
+  };
+
+  log(repo, 'Fetching artifacts from Harbor...');
+  const artifacts = await harbor.listArtifacts('library', repo);
+  log(repo, `Found ${artifacts.length} artifact(s) with tags`);
+
+  const catalog = catalogTags(artifacts);
+  log(
+    repo,
+    `Tags: ${catalog.sha.length} sha, ${catalog.pr.length} pr, ${catalog.prod.length} prod, ${catalog.legacy.length} legacy`,
+  );
+
+  // ── Collect safe sha7 values that must never be deleted ───────────────────
+  const openPrs = await github.listOpenPullRequests();
+  const openPrSha7s = new Set(openPrs.map((pr) => pr.headSha.slice(0, 7)));
+  log(
+    repo,
+    `Open PRs: ${openPrs.length} (head sha7s: ${[...openPrSha7s].join(', ') || 'none'})`,
+  );
+
+  const prodSha7s = new Set(catalog.prod.map((t) => t.sha7));
+
+  const safeToDelete = (tag: string): boolean => {
+    if (deployedTags.has(tag)) {
+      log(repo, `  SKIP (deployed in cluster): ${tag}`);
+      result.skippedDeployed.push(tag);
+      return false;
+    }
+    return true;
+  };
+
+  const deleteTag = async (tag: string, digest: string) => {
+    try {
+      await harbor.deleteTag('library', repo, digest, tag);
+      log(repo, `  DELETED: ${tag}`);
+      result.deleted.push(tag);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log(repo, `  ERROR deleting ${tag}: ${msg}`);
+      result.errors.push(`${tag}: ${msg}`);
+    }
+  };
+
+  // ── 1. Legacy semver tags ─────────────────────────────────────────────────
+  log(repo, `Processing ${catalog.legacy.length} legacy tag(s)...`);
+  for (const t of catalog.legacy) {
+    if (safeToDelete(t.tag)) {
+      log(repo, `  Queued legacy delete: ${t.tag}`);
+      await deleteTag(t.tag, t.digest);
+    }
+  }
+
+  // ── 2. PR tags (backwards-compat: pr-<N>-<sha7> format) ──────────────────
+  log(repo, `Processing ${catalog.pr.length} pr tag(s)...`);
+  const prGroups = new Map<number, PrTag[]>();
+  for (const t of catalog.pr) {
+    const group = prGroups.get(t.prNumber) ?? [];
+    group.push(t);
+    prGroups.set(t.prNumber, group);
+  }
+
+  for (const [prNumber, tags] of prGroups) {
+    const pr = await github.getPullRequest(prNumber);
+
+    if (!pr || pr.state === 'closed') {
+      log(repo, `  PR #${prNumber} is closed — deleting ${tags.length} tag(s)`);
+      for (const t of tags) {
+        if (safeToDelete(t.tag)) await deleteTag(t.tag, t.digest);
+      }
+    } else {
+      const currentSha7 = pr.headSha.slice(0, 7);
+      for (const t of tags) {
+        if (t.sha7 === currentSha7) {
+          log(repo, `  KEEP (current head of open PR #${prNumber}): ${t.tag}`);
+          result.kept.push(t.tag);
+        } else {
+          log(
+            repo,
+            `  PR #${prNumber} open but stale sha — deleting: ${t.tag}`,
+          );
+          if (safeToDelete(t.tag)) await deleteTag(t.tag, t.digest);
+        }
+      }
+    }
+  }
+
+  // ── 3. SHA tags ───────────────────────────────────────────────────────────
+  log(repo, `Processing ${catalog.sha.length} sha tag(s)...`);
+  for (const t of catalog.sha) {
+    const referencedByOpenPr = openPrSha7s.has(t.sha7);
+    const referencedByProd = prodSha7s.has(t.sha7);
+
+    if (referencedByOpenPr) {
+      log(repo, `  KEEP (open PR head): ${t.tag}`);
+      result.kept.push(t.tag);
+    } else if (referencedByProd) {
+      log(repo, `  KEEP (referenced by prod tag): ${t.tag}`);
+      result.kept.push(t.tag);
+    } else {
+      if (safeToDelete(t.tag)) await deleteTag(t.tag, t.digest);
+    }
+  }
+
+  // ── 4. Production tags — keep most recent N, protect deployed ─────────────
+  log(
+    repo,
+    `Processing ${catalog.prod.length} prod tag(s), keeping ${config.prodKeepCount}...`,
+  );
+  const sortedProd = sortProdTagsDesc(catalog.prod);
+  let kept = 0;
+
+  for (const t of sortedProd) {
+    if (deployedTags.has(t.tag)) {
+      log(repo, `  KEEP (deployed in cluster): ${t.tag}`);
+      result.skippedDeployed.push(t.tag);
+      kept++;
+      continue;
+    }
+    if (kept < config.prodKeepCount) {
+      log(
+        repo,
+        `  KEEP (within retention window ${kept + 1}/${config.prodKeepCount}): ${t.tag}`,
+      );
+      result.kept.push(t.tag);
+      kept++;
+    } else {
+      await deleteTag(t.tag, t.digest);
+    }
+  }
+
+  result.durationMs = Date.now() - start;
+  return result;
+}
+
+export async function runCleanup(): Promise<CleanupResult> {
+  const start = Date.now();
+  console.log('[cleanup] Starting cleanup run');
+
+  const harbor = new HarborClient(
+    config.harbor.host,
+    config.harbor.username,
+    config.harbor.password,
+  );
+  const github = new GitHubClient(
+    config.gitHub.token,
+    config.gitHub.owner,
+    config.gitHub.repo,
+  );
+  const k8s = new KubernetesClient();
+
+  const deployedTags = await k8s.getDeployedImageTags(config.harbor.host);
+
+  const repos = config.cleanupRepositories
+    .split(',')
+    .map((r) => r.trim())
+    .filter(Boolean);
+  const results: RepositoryCleanupResult[] = [];
+
+  for (const repo of repos) {
+    console.log(`[cleanup] Processing repository: ${repo}`);
+    try {
+      const result = await cleanupRepository(
+        repo,
+        harbor,
+        github,
+        deployedTags,
+      );
+      results.push(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[cleanup] Fatal error for repository ${repo}: ${msg}`);
+      results.push({
+        repository: repo,
+        deleted: [],
+        kept: [],
+        skippedDeployed: [],
+        errors: [msg],
+        durationMs: 0,
+      });
+    }
+  }
+
+  const totalDeleted = results.reduce((sum, r) => sum + r.deleted.length, 0);
+  const totalErrors = results.reduce((sum, r) => sum + r.errors.length, 0);
+  const durationMs = Date.now() - start;
+
+  console.log(
+    `[cleanup] Done. Deleted ${totalDeleted} tag(s), ${totalErrors} error(s) in ${durationMs}ms`,
+  );
+  return { repositories: results, totalDeleted, totalErrors, durationMs };
+}

--- a/apps/harbor-cleanup/src/services/tagParser.ts
+++ b/apps/harbor-cleanup/src/services/tagParser.ts
@@ -1,0 +1,81 @@
+import type { HarborArtifact } from '../api/harbor/harborClient';
+
+export const SHA_TAG_RE = /^sha-([0-9a-f]{7})$/;
+export const PR_TAG_RE = /^pr-(\d+)-([0-9a-f]{7})$/;
+export const PROD_TAG_RE = /^(\d{8})-(\d+)-([0-9a-f]{7})$/;
+
+export type ShaTag = { kind: 'sha'; sha7: string; tag: string; digest: string };
+export type PrTag = {
+  kind: 'pr';
+  prNumber: number;
+  sha7: string;
+  tag: string;
+  digest: string;
+};
+export type ProdTag = {
+  kind: 'prod';
+  date: string;
+  run: number;
+  sha7: string;
+  tag: string;
+  digest: string;
+};
+export type LegacyTag = { kind: 'legacy'; tag: string; digest: string };
+export type ParsedTag = ShaTag | PrTag | ProdTag | LegacyTag;
+
+export type TagCatalog = {
+  sha: ShaTag[];
+  pr: PrTag[];
+  prod: ProdTag[];
+  legacy: LegacyTag[];
+};
+
+export function parseTag(tag: string, digest: string): ParsedTag {
+  let m: RegExpMatchArray | null;
+
+  m = tag.match(SHA_TAG_RE);
+  if (m) return { kind: 'sha', sha7: m[1], tag, digest };
+
+  m = tag.match(PR_TAG_RE);
+  if (m)
+    return {
+      kind: 'pr',
+      prNumber: parseInt(m[1], 10),
+      sha7: m[2],
+      tag,
+      digest,
+    };
+
+  m = tag.match(PROD_TAG_RE);
+  if (m)
+    return {
+      kind: 'prod',
+      date: m[1],
+      run: parseInt(m[2], 10),
+      sha7: m[3],
+      tag,
+      digest,
+    };
+
+  return { kind: 'legacy', tag, digest };
+}
+
+export function catalogTags(artifacts: HarborArtifact[]): TagCatalog {
+  const catalog: TagCatalog = { sha: [], pr: [], prod: [], legacy: [] };
+
+  for (const artifact of artifacts) {
+    for (const t of artifact.tags ?? []) {
+      const parsed = parseTag(t.name, artifact.digest);
+      (catalog[parsed.kind] as ParsedTag[]).push(parsed);
+    }
+  }
+
+  return catalog;
+}
+
+export function sortProdTagsDesc(tags: ProdTag[]): ProdTag[] {
+  return [...tags].sort((a, b) => {
+    const d = b.date.localeCompare(a.date);
+    return d !== 0 ? d : b.run - a.run;
+  });
+}

--- a/apps/harbor-cleanup/tests/jest.integration.setup.ts
+++ b/apps/harbor-cleanup/tests/jest.integration.setup.ts
@@ -1,0 +1,13 @@
+import { createServer } from '../src/server';
+import { initConfig, validateConfig } from '../src/config';
+import request from 'supertest';
+
+let app: ReturnType<typeof createServer>;
+
+beforeAll(async () => {
+  await initConfig();
+  validateConfig();
+  app = createServer();
+});
+
+export const getRequest = () => request(app);

--- a/apps/harbor-cleanup/tests/unit/tagParser.unit.test.ts
+++ b/apps/harbor-cleanup/tests/unit/tagParser.unit.test.ts
@@ -1,0 +1,127 @@
+import {
+  parseTag,
+  catalogTags,
+  sortProdTagsDesc,
+} from '../../src/services/tagParser';
+import type { HarborArtifact } from '../../src/api/harbor/harborClient';
+
+const DIGEST = 'sha256:abc';
+
+describe('parseTag', () => {
+  it('parses sha tags', () => {
+    const result = parseTag('sha-abc1234', DIGEST);
+    expect(result).toEqual({
+      kind: 'sha',
+      sha7: 'abc1234',
+      tag: 'sha-abc1234',
+      digest: DIGEST,
+    });
+  });
+
+  it('parses pr tags', () => {
+    const result = parseTag('pr-105-abc1234', DIGEST);
+    expect(result).toEqual({
+      kind: 'pr',
+      prNumber: 105,
+      sha7: 'abc1234',
+      tag: 'pr-105-abc1234',
+      digest: DIGEST,
+    });
+  });
+
+  it('parses prod tags', () => {
+    const result = parseTag('20260601-42-abc1234', DIGEST);
+    expect(result).toEqual({
+      kind: 'prod',
+      date: '20260601',
+      run: 42,
+      sha7: 'abc1234',
+      tag: '20260601-42-abc1234',
+      digest: DIGEST,
+    });
+  });
+
+  it('classifies semver as legacy', () => {
+    expect(parseTag('0.7.0', DIGEST)).toEqual({
+      kind: 'legacy',
+      tag: '0.7.0',
+      digest: DIGEST,
+    });
+    expect(parseTag('v1.2.3', DIGEST)).toEqual({
+      kind: 'legacy',
+      tag: 'v1.2.3',
+      digest: DIGEST,
+    });
+  });
+
+  it('classifies unknown tags as legacy', () => {
+    expect(parseTag('latest', DIGEST)).toEqual({
+      kind: 'legacy',
+      tag: 'latest',
+      digest: DIGEST,
+    });
+    expect(parseTag('main', DIGEST)).toEqual({
+      kind: 'legacy',
+      tag: 'main',
+      digest: DIGEST,
+    });
+  });
+});
+
+describe('catalogTags', () => {
+  it('sorts tags into correct buckets', () => {
+    const artifacts: HarborArtifact[] = [
+      {
+        digest: 'sha256:aaa',
+        tags: [{ name: 'sha-abc1234' }, { name: '20260601-1-abc1234' }],
+      },
+      { digest: 'sha256:bbb', tags: [{ name: 'pr-42-def5678' }] },
+      { digest: 'sha256:ccc', tags: [{ name: '0.6.0' }] },
+      { digest: 'sha256:ddd', tags: [] },
+    ];
+
+    const catalog = catalogTags(artifacts);
+
+    expect(catalog.sha).toHaveLength(1);
+    expect(catalog.prod).toHaveLength(1);
+    expect(catalog.pr).toHaveLength(1);
+    expect(catalog.legacy).toHaveLength(1);
+  });
+});
+
+describe('sortProdTagsDesc', () => {
+  it('sorts by date descending then run descending', () => {
+    const tags = [
+      {
+        kind: 'prod' as const,
+        date: '20260601',
+        run: 1,
+        sha7: 'aaa0001',
+        tag: '20260601-1-aaa0001',
+        digest: 'sha256:1',
+      },
+      {
+        kind: 'prod' as const,
+        date: '20260601',
+        run: 5,
+        sha7: 'bbb0002',
+        tag: '20260601-5-bbb0002',
+        digest: 'sha256:2',
+      },
+      {
+        kind: 'prod' as const,
+        date: '20260530',
+        run: 3,
+        sha7: 'ccc0003',
+        tag: '20260530-3-ccc0003',
+        digest: 'sha256:3',
+      },
+    ];
+
+    const sorted = sortProdTagsDesc(tags);
+
+    expect(sorted[0].tag).toBe('20260601-5-bbb0002');
+    expect(sorted[1].tag).toBe('20260601-1-aaa0001');
+    expect(sorted[2].tag).toBe('20260530-3-ccc0003');
+  });
+});

--- a/apps/harbor-cleanup/tsconfig.build.json
+++ b/apps/harbor-cleanup/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "description": "Typescript configuration for building the project",
+  "extends": "@abbottland/typescript-config/ts-server-build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/apps/harbor-cleanup/tsconfig.json
+++ b/apps/harbor-cleanup/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "description": "Typescript configuration for VS Code",
+  "extends": "@abbottland/typescript-config/ts-server-base.json",
+  "compilerOptions": {
+    "types": ["node", "express", "jest"]
+  }
+}

--- a/apps/harbor-cleanup/tsconfig.test.json
+++ b/apps/harbor-cleanup/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "description": "Typescript configuration for running tests",
+  "extends": "@abbottland/typescript-config/ts-server-test.json",
+  "include": ["**/*.test.ts"]
+}

--- a/docker/pnpm-turbo.Dockerfile
+++ b/docker/pnpm-turbo.Dockerfile
@@ -38,6 +38,9 @@ RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store pnpm install --frozen-lockfi
 ###############################################################
 FROM npm AS development
 
+ARG IMAGE_TAG=""
+ENV IMAGE_TAG=${IMAGE_TAG}
+
 # Copy source code of isolated subworkspace
 COPY --from=pruner /app/out/full .
 RUN turbo build --filter=@abbottland/${PROJECT} --log-prefix=none

--- a/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.ts
+++ b/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.ts
@@ -19,6 +19,7 @@ export const makeBuildSettings = (
     // The trailing slash is needed here because of the dockerfile.
     buildArgs.PROJECT_DIR = `${projectMetadata.parentDirName}/`
     buildArgs.PROJECT = projectMetadata.projectName
+    buildArgs.IMAGE_TAG = image.split(':').pop() ?? ''
   }
 
   return {

--- a/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.unit.test.ts
+++ b/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.unit.test.ts
@@ -3,7 +3,7 @@ import {ProjectMetadata} from '../project-metadata.js'
 import {makeBuildSettings} from './docker-build-settings-builder.js'
 
 describe('@abbottland/abctl/docker-build-settings-builder makeBuildSettings', () => {
-  const image = 'one_cool_image'
+  const image = 'one_cool_image:20260101-1-abc1234'
 
   const dockerBuildConfig: DockerBuildConfig = {
     baseImage: 'node:22-alpine',
@@ -44,6 +44,7 @@ describe('@abbottland/abctl/docker-build-settings-builder makeBuildSettings', ()
         BASE_IMAGE: dockerBuildConfig.baseImage,
         PROJECT_DIR: `${projectMetadata.parentDirName}/`,
         PROJECT: projectMetadata.projectName,
+        IMAGE_TAG: '20260101-1-abc1234',
       })
     })
     it('should not set cacheRef', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,9 +321,15 @@ importers:
       '@kubernetes/client-node':
         specifier: ^0.22.3
         version: 0.22.3
+      cronstrue:
+        specifier: ^2.59.0
+        version: 2.59.0
       express:
         specifier: 'catalog:'
         version: 5.1.0
+      node-cron:
+        specifier: ^3.0.3
+        version: 3.0.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -349,6 +355,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
+      '@types/node-cron':
+        specifier: ^3.0.11
+        version: 3.0.11
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
@@ -13615,7 +13624,7 @@ snapshots:
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.37.0(jiti@2.6.1))
@@ -13710,7 +13719,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13792,7 +13801,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,73 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  apps/harbor-cleanup:
+    dependencies:
+      '@abbottland/express':
+        specifier: workspace:*
+        version: link:../../packages/express
+      '@abbottland/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
+      '@abbottland/yaml-config':
+        specifier: workspace:*
+        version: link:../../packages/yaml-config
+      '@kubernetes/client-node':
+        specifier: ^0.22.3
+        version: 0.22.3
+      express:
+        specifier: 'catalog:'
+        version: 5.1.0
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+    devDependencies:
+      '@abbottland/abctl':
+        specifier: workspace:*
+        version: link:../../packages/abctl
+      '@abbottland/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@abbottland/jest-presets':
+        specifier: workspace:*
+        version: link:../../packages/jest-presets
+      '@abbottland/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/express':
+        specifier: 'catalog:'
+        version: 5.0.3
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 29.5.14
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      dotenv:
+        specifier: ^16.6.1
+        version: 16.6.1
+      jest:
+        specifier: 'catalog:'
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@25.9.1)(typescript@5.9.3))
+      jest-junit:
+        specifier: ^16.0.0
+        version: 16.0.0
+      supertest:
+        specifier: ^7.1.4
+        version: 7.1.4
+      ts-node:
+        specifier: 'catalog:'
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@25.9.1)(typescript@5.9.3)
+      tsc-watch:
+        specifier: ^6.3.1
+        version: 6.3.1(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   apps/pi-led-api:
     dependencies:
       '@abbottland/express':
@@ -1901,6 +1968,10 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -2002,6 +2073,21 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@kubernetes/client-node@0.22.3':
+    resolution: {integrity: sha512-dG8uah3+HDJLpJEESshLRZlAZ4PgDeV9mZXT0u1g7oy4KMRzdZ7n5g0JEIlL6QhK51/2ztcIqURAnjfjJt6Z+g==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -4113,6 +4199,13 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
@@ -4150,6 +4243,12 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
@@ -4201,6 +4300,9 @@ packages:
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -4257,6 +4359,10 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4301,6 +4407,9 @@ packages:
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4356,6 +4465,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -4471,6 +4584,9 @@ packages:
   core-js-compat@3.46.0:
     resolution: {integrity: sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==}
 
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
@@ -4537,6 +4653,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -4736,6 +4856,9 @@ packages:
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -5212,6 +5335,10 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -5302,9 +5429,16 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
+
+  form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
 
   form-data@4.0.2:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
@@ -5421,6 +5555,9 @@ packages:
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
   git-hooks-list@3.2.0:
     resolution: {integrity: sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==}
 
@@ -5495,6 +5632,15 @@ packages:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
+
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -5590,6 +5736,10 @@ packages:
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
+
+  http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
 
   http2-wrapper@2.2.1:
     resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
@@ -5845,6 +5995,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -5886,6 +6039,14 @@ packages:
   isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -6064,6 +6225,9 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -6078,9 +6242,16 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
   jsdoc-type-pratt-parser@4.1.0:
     resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
     engines: {node: '>=12.0.0'}
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -6106,8 +6277,14 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -6123,6 +6300,15 @@ packages:
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -6546,6 +6732,10 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -6759,6 +6949,12 @@ packages:
       - which
       - write-file-atomic
 
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -6828,6 +7024,9 @@ packages:
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
+
+  openid-client@6.8.4:
+    resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -6980,6 +7179,9 @@ packages:
   pause-stream@0.0.11:
     resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
 
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -7095,6 +7297,9 @@ packages:
     engines: {node: '>= 0.10'}
     hasBin: true
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -7108,6 +7313,10 @@ packages:
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
+  qs@6.5.5:
+    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.8:
@@ -7301,6 +7510,11 @@ packages:
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
+  request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -7351,6 +7565,9 @@ packages:
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
 
   rollup@4.52.5:
     resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==}
@@ -7568,6 +7785,11 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -7607,6 +7829,10 @@ packages:
         optional: true
       vite-plus:
         optional: true
+
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
 
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
@@ -7747,6 +7973,10 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -7804,6 +8034,10 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -7935,6 +8169,9 @@ packages:
   turbo@2.5.0:
     resolution: {integrity: sha512-PvSRruOsitjy6qdqwIIyolv99+fEn57gP6gn4zhsHTEcCYgXPhv6BAxzAjleS8XKpo+Y582vTTA9nuqYDmbRuA==}
     hasBin: true
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -8136,6 +8373,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -8158,6 +8400,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -8360,6 +8606,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
@@ -9871,6 +10121,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
       camelcase: 5.3.1
@@ -10074,6 +10328,32 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@kubernetes/client-node@0.22.3':
+    dependencies:
+      byline: 5.0.0
+      isomorphic-ws: 5.0.0(ws@8.18.3)
+      js-yaml: 4.1.0
+      jsonpath-plus: 10.4.0
+      request: 2.88.2
+      rfc4648: 1.5.4
+      stream-buffers: 3.0.3
+      tar: 7.5.15
+      tslib: 2.8.1
+      ws: 8.18.3
+    optionalDependencies:
+      openid-client: 6.8.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -12493,6 +12773,12 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
   assertion-error@1.1.0: {}
 
   assertion-error@2.0.1: {}
@@ -12524,6 +12810,10 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
 
   axe-core@4.11.0: {}
 
@@ -12596,6 +12886,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -12663,6 +12957,8 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  byline@5.0.0: {}
+
   bytes@3.1.2: {}
 
   cacheable-lookup@7.0.0: {}
@@ -12712,6 +13008,8 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
       upper-case-first: 2.0.2
+
+  caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
@@ -12786,6 +13084,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chownr@3.0.0: {}
 
   ci-info@3.9.0: {}
 
@@ -12876,6 +13176,8 @@ snapshots:
     dependencies:
       browserslist: 4.26.3
 
+  core-util-is@1.0.2: {}
+
   cors@2.8.5:
     dependencies:
       object-assign: 4.1.1
@@ -12947,6 +13249,10 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
+
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -13098,6 +13404,11 @@ snapshots:
       gopd: 1.2.0
 
   duplexer@0.1.2: {}
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
 
   ee-first@1.1.1: {}
 
@@ -13992,6 +14303,8 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
+  extsprintf@1.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -14094,7 +14407,15 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  forever-agent@0.6.1: {}
+
   form-data-encoder@2.1.4: {}
+
+  form-data@2.3.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   form-data@4.0.2:
     dependencies:
@@ -14219,6 +14540,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
+
   git-hooks-list@3.2.0: {}
 
   github-slugger@2.0.0: {}
@@ -14309,6 +14634,13 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.19.3
+
+  har-schema@2.0.0: {}
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
 
   has-bigints@1.1.0: {}
 
@@ -14472,6 +14804,12 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+
+  http-signature@1.2.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.18.0
 
   http2-wrapper@2.2.1:
     dependencies:
@@ -14694,6 +15032,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.19
 
+  is-typedarray@1.0.0: {}
+
   is-unicode-supported@2.1.0: {}
 
   is-weakmap@2.0.2: {}
@@ -14724,6 +15064,12 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.1: {}
+
+  isomorphic-ws@5.0.0(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
+
+  isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -15140,6 +15486,9 @@ snapshots:
 
   jju@1.4.0: {}
 
+  jose@6.2.3:
+    optional: true
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -15153,7 +15502,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbn@0.1.1: {}
+
   jsdoc-type-pratt-parser@4.1.0: {}
+
+  jsep@1.4.0: {}
 
   jsesc@0.5.0: {}
 
@@ -15169,7 +15522,11 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
     dependencies:
@@ -15186,6 +15543,19 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
+
+  jsprim@1.4.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -15755,6 +16125,10 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mkdirp@1.0.4: {}
 
   mlly@1.7.4:
@@ -15882,6 +16256,11 @@ snapshots:
 
   npm@10.9.4: {}
 
+  oauth-sign@0.9.0: {}
+
+  oauth4webapi@3.8.6:
+    optional: true
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -15989,6 +16368,12 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  openid-client@6.8.4:
+    dependencies:
+      jose: 6.2.3
+      oauth4webapi: 3.8.6
+    optional: true
 
   optionator@0.9.4:
     dependencies:
@@ -16178,6 +16563,8 @@ snapshots:
     dependencies:
       through: 2.3.8
 
+  performance-now@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -16282,6 +16669,10 @@ snapshots:
     dependencies:
       event-stream: 3.3.4
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
@@ -16291,6 +16682,8 @@ snapshots:
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.5.5: {}
 
   quansync@0.2.8: {}
 
@@ -16548,6 +16941,29 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  request@2.88.2:
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.5
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -16585,6 +17001,8 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.0.4: {}
+
+  rfc4648@1.5.4: {}
 
   rollup@4.52.5:
     dependencies:
@@ -16896,6 +17314,18 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
   stable-hash@0.0.5: {}
 
   stack-utils@2.0.6:
@@ -16943,6 +17373,8 @@ snapshots:
       - react
       - react-dom
       - utf-8-validate
+
+  stream-buffers@3.0.3: {}
 
   stream-combiner@0.0.4:
     dependencies:
@@ -17113,6 +17545,14 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   term-size@2.2.1: {}
 
   test-exclude@6.0.0:
@@ -17155,6 +17595,11 @@ snapshots:
   toidentifier@1.0.1: {}
 
   totalist@3.0.1: {}
+
+  tough-cookie@2.5.0:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
 
   tr46@0.0.3: {}
 
@@ -17281,6 +17726,8 @@ snapshots:
       turbo-linux-arm64: 2.5.0
       turbo-windows-64: 2.5.0
       turbo-windows-arm64: 2.5.0
+
+  tweetnacl@0.14.5: {}
 
   type-check@0.4.0:
     dependencies:
@@ -17524,6 +17971,8 @@ snapshots:
     dependencies:
       react: 19.2.0
 
+  uuid@3.4.0: {}
+
   uuid@8.3.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
@@ -17542,6 +17991,12 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
 
   vfile-location@5.0.3:
     dependencies:
@@ -17787,6 +18242,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.1: {}
 

--- a/scripts/docker-publish-sha.sh
+++ b/scripts/docker-publish-sha.sh
@@ -11,4 +11,4 @@ SHORT_SHA="${COMMIT_SHA::7}"
 export ABCTL_IMAGE_TAG="sha-${SHORT_SHA}"
 
 echo "Publishing app images with tag: ${ABCTL_IMAGE_TAG}"
-pnpm turbo run docker:publish --filter='./apps/*'
+pnpm turbo run docker:publish --filter='./apps/*' --filter='./packages/fui-components'

--- a/scripts/docker-retag-prod.sh
+++ b/scripts/docker-retag-prod.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Local usage:
 #   COMMIT_SHA=<merge-commit-sha> RUN_NUMBER=42 bash ./scripts/docker-retag-prod.sh
+#   APPS="blog diagram-maker" COMMIT_SHA=<sha> RUN_NUMBER=42 bash ./scripts/docker-retag-prod.sh
 #
 # Finds the PR branch head SHA from the merge commit's second parent,
-# then retags the existing sha-<sha7> image with a production tag.
+# then retags each app's sha-<sha7> image with a production tag.
 # Falls back to COMMIT_SHA directly for squash/direct-push merges.
 
 set -euo pipefail
@@ -11,7 +12,8 @@ cd "$(dirname "$0")/.."
 
 COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
 RUN_NUMBER="${RUN_NUMBER:?RUN_NUMBER is required}"
-IMAGE_REPO="${IMAGE_REPO:-harbor.local.abbottland.io/library/blog}"
+REGISTRY="${REGISTRY:-harbor.local.abbottland.io/library}"
+APPS="${APPS:-blog diagram-maker fui-components gluetun-sync harbor-cleanup}"
 
 PARENTS=$(git log --pretty=%P -1 "$COMMIT_SHA")
 PARENT_COUNT=$(echo "$PARENTS" | wc -w)
@@ -28,7 +30,10 @@ SHORT_SHA="${SOURCE_SHA::7}"
 DATE=$(date +%Y%m%d)
 PROD_TAG="${DATE}-${RUN_NUMBER}-${SHORT_SHA}"
 
-echo "Retagging ${IMAGE_REPO}:sha-${SHORT_SHA} → ${IMAGE_REPO}:${PROD_TAG}"
-docker buildx imagetools create \
-  --tag "${IMAGE_REPO}:${PROD_TAG}" \
-  "${IMAGE_REPO}:sha-${SHORT_SHA}"
+for APP in $APPS; do
+  IMAGE_REPO="${REGISTRY}/${APP}"
+  echo "Retagging ${IMAGE_REPO}:sha-${SHORT_SHA} → ${IMAGE_REPO}:${PROD_TAG}"
+  docker buildx imagetools create \
+    --tag "${IMAGE_REPO}:${PROD_TAG}" \
+    "${IMAGE_REPO}:sha-${SHORT_SHA}"
+done


### PR DESCRIPTION
## Summary

- Adds `harbor-cleanup` — Express service that prunes stale SHA, PR, and old prod tags from Harbor, keeping the most recent N prod images per repository
- Extends Docker publish pipeline to cover all releasable apps (blog, diagram-maker, fui-components, gluetun-sync, harbor-cleanup) instead of blog only
- Fixes `fui-components` SHA image gap: was excluded from turbo `./apps/*` filter, now explicitly included
- Drops semver/changeset publication docs; replaces with SHA-based publication guide

## Test plan

- [ ] Unit tests pass (`pnpm test:unit`)
- [ ] Integration tests pass (`pnpm test:int`)
- [ ] Harbor cleanup status endpoint responds at `GET /status`
- [ ] Manual cleanup trigger responds at `POST /cleanup`
- [ ] Verify `docker-publish-sha.sh` pushes `fui-components` SHA tag on next PR CI run
- [ ] Verify `docker-retag-prod.sh` retags all 5 apps on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)