### PR TITLE
fix(blog): bake IMAGE_TAG into next build for correct footer display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         shell: bash
         env:
           COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          RUN_NUMBER: ${{ github.run_number }}
 
       - name: Build
         run: pnpm build
@@ -157,6 +158,7 @@ jobs:
         run: bash ./scripts/docker-publish-sha.sh
         env:
           COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          RUN_NUMBER: ${{ github.run_number }}
 
   fui-components-ui-tests:
     needs: [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
           echo "TURBO_TEAM=$TURBO_TEAM" >> $GITHUB_ENV
         shell: bash
 
+      - name: Set image tag
+        run: bash ./scripts/set-image-tag.sh
+        shell: bash
+        env:
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
       - name: Build
         run: pnpm build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["harbor.local.abbottland.io/proxy-dockerhub"]
+            [registry."ghcr.io"]
+              mirrors = ["harbor.local.abbottland.io/proxy-ghcr"]
 
       - name: Free runner disk space
         run: docker system prune -f

--- a/docs/image-tag-footer-tracing.md
+++ b/docs/image-tag-footer-tracing.md
@@ -1,0 +1,132 @@
+# Image Tag Footer — End-to-End Trace
+
+Documents how `IMAGE_TAG` flows from source code to the live footer value.
+
+## Footer source
+
+`apps/blog/src/app/(home)/FooterSection/FooterSection.tsx`
+
+```tsx
+const imageTag = process.env.IMAGE_TAG ?? 'dev';
+```
+
+`apps/blog/next.config.mjs`
+
+```js
+env: {
+  IMAGE_TAG: process.env.IMAGE_TAG ?? 'dev',
+},
+```
+
+The `env` block in `next.config.mjs` inlines `IMAGE_TAG` into the Next.js bundle at **build time**. The home page is `'use client'`, which means it is statically pre-rendered (SSG) during `next build` — the footer HTML is generated once and baked in. The runtime pod env var does **not** re-render the footer.
+
+---
+
+## Path A — CI build (authoritative)
+
+This is the path that determines what value ends up in the shipped image.
+
+```
+set-image-tag.sh
+  → IMAGE_TAG=sha-<sha7>
+  → $GITHUB_ENV
+    → pnpm build (next build)
+      → next.config env: { IMAGE_TAG } inlines value
+        → .next/server/app/index.html contains sha-<sha7>
+          → artifact uploaded
+```
+
+### Step details
+
+| Step | Where                                 | What happens                                                                                                |
+| ---- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 1    | `ci.yml` `build` job                  | `set-image-tag.sh` runs, writes `IMAGE_TAG=sha-<sha7>` to `$GITHUB_ENV`                                     |
+| 2    | `ci.yml` `build` job                  | `pnpm build` runs with `IMAGE_TAG` in environment                                                           |
+| 3    | `apps/blog/next.config.mjs`           | `env: { IMAGE_TAG }` inlines value into `next build` output                                                 |
+| 4    | `turbo.json` `@abbottland/blog#build` | `"env": ["IMAGE_TAG"]` includes the value in the Turbo cache key — different SHA = cache miss = fresh build |
+| 5    | `.next/server/app/index.html`         | Footer HTML contains the baked `sha-<sha7>` value                                                           |
+| 6    | `ci.yml` `build` job                  | `.next/**` artifact uploaded                                                                                |
+
+---
+
+## Path B — Docker build (secondary)
+
+When `abctl docker:publish` builds the `blog-base` image via `pnpm-turbo.Dockerfile`, it also runs `next build` inside Docker. Turbo remote cache (populated in Path A with the same `IMAGE_TAG`) produces a cache hit, so the identical pre-built `.next` is reused. No double-baking occurs.
+
+```
+docker-publish-sha.sh
+  → ABCTL_IMAGE_TAG=sha-<sha7>
+  → abctl docker:publish
+    → makeBuildSettings (docker-build-settings-builder.ts)
+      → buildArgs.IMAGE_TAG = sha-<sha7>   (extracted from image ref)
+        → pnpm-turbo.Dockerfile
+          → ARG IMAGE_TAG → ENV IMAGE_TAG=sha-<sha7>
+            → turbo build (cache HIT — same key as Path A)
+              → .next output reused unchanged
+```
+
+If there is no remote cache hit (e.g. fresh runner), `next build` runs with `IMAGE_TAG=sha-<sha7>` and bakes the same value.
+
+---
+
+## Path C — Production retag
+
+`docker-publish.yml` triggers on push to `main`. It **does not rebuild** the image.
+
+```
+docker-retag-prod.sh
+  → finds PR branch head SHA from merge commit's second parent
+  → docker buildx imagetools create
+      blog:sha-<sha7>  →  blog:<YYYYMMDD>-<run>-<sha7>
+```
+
+The retag copies the manifest digest with no new layers. The footer value baked into the image remains `sha-<sha7>`.
+
+> **Implication:** The footer shows `sha-<sha7>`, not `<YYYYMMDD>-<run>-<sha7>`. If the production tag format is required in the footer, the Docker build would need to be triggered from `docker-publish.yml` rather than a retag, or the production tag would need to be injected at runtime.
+
+---
+
+## Path D — Kubernetes runtime (PR preview)
+
+`deploy-preview.sh` exports `IMAGE_TAG` (extracted from the Docker image reference, e.g. `sha-<sha7>`) and substitutes it into the deployment manifest via `envsubst`:
+
+```yaml
+# apps/blog/k8s/pr-preview/deployment.yaml
+env:
+  - name: IMAGE_TAG
+    value: '${IMAGE_TAG}'
+```
+
+This sets `IMAGE_TAG` as a Node.js process env var in the running pod. For dynamically rendered routes, Next.js would read it at request time. However, the home page is statically pre-rendered — the footer HTML was already generated during `next build`. The runtime env var has no effect on the footer.
+
+---
+
+## Value by environment
+
+| Environment              | Footer shows | Set by                                            |
+| ------------------------ | ------------ | ------------------------------------------------- |
+| Local dev                | `dev`        | `?? 'dev'` fallback in `next.config.mjs`          |
+| CI artifact / PR preview | `sha-<sha7>` | `set-image-tag.sh` → `$GITHUB_ENV` → `next build` |
+| Production (retagged)    | `sha-<sha7>` | Same baked value — retag does not rebuild         |
+
+---
+
+## Why it showed `dev` before the fix
+
+1. `next build` in the CI `build` job ran with no `IMAGE_TAG` set → `'dev'` fallback baked in
+2. Turbo remote cache stored this `dev` output
+3. Docker build (`pnpm-turbo.Dockerfile`) ran `turbo build` → cache hit → reused `dev` output
+4. `IMAGE_TAG` was not in `@abbottland/blog#build`'s `env` cache key → Turbo never invalidated on SHA change
+
+---
+
+## Files changed to fix this
+
+| File                                                  | Change                                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------ |
+| `apps/blog/next.config.mjs`                           | Added `env: { IMAGE_TAG }` to inline at build time           |
+| `docker/pnpm-turbo.Dockerfile`                        | Added `ARG IMAGE_TAG` / `ENV IMAGE_TAG` before `turbo build` |
+| `packages/abctl/.../docker-build-settings-builder.ts` | Pass `IMAGE_TAG` build arg (extracted from image tag)        |
+| `turbo.json`                                          | Added `"env": ["IMAGE_TAG"]` to `@abbottland/blog#build`     |
+| `scripts/set-image-tag.sh`                            | New script: computes `sha-<sha7>`, writes to `$GITHUB_ENV`   |
+| `.github/workflows/ci.yml`                            | Call `set-image-tag.sh` before `pnpm build` in `build` job   |

--- a/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.ts
+++ b/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.ts
@@ -19,6 +19,7 @@ export const makeBuildSettings = (
     // The trailing slash is needed here because of the dockerfile.
     buildArgs.PROJECT_DIR = `${projectMetadata.parentDirName}/`
     buildArgs.PROJECT = projectMetadata.projectName
+    buildArgs.IMAGE_TAG = process.env.IMAGE_TAG ?? image.split(':').pop() ?? ''
   }
 
   return {

--- a/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.unit.test.ts
+++ b/packages/abctl/src/build-logic/docker-build-settings-builder/docker-build-settings-builder.unit.test.ts
@@ -3,7 +3,7 @@ import {ProjectMetadata} from '../project-metadata.js'
 import {makeBuildSettings} from './docker-build-settings-builder.js'
 
 describe('@abbottland/abctl/docker-build-settings-builder makeBuildSettings', () => {
-  const image = 'one_cool_image'
+  const image = 'one_cool_image:20260101-001-abc1234'
 
   const dockerBuildConfig: DockerBuildConfig = {
     baseImage: 'node:22-alpine',
@@ -39,15 +39,32 @@ describe('@abbottland/abctl/docker-build-settings-builder makeBuildSettings', ()
     it('should set target', () => {
       expect(sut.target).toBe(dockerBuildConfig.target)
     })
-    it('should set build args', () => {
+    it('should set build args with IMAGE_TAG from image ref when env var not set', () => {
       expect(sut.buildArgs).toEqual({
         BASE_IMAGE: dockerBuildConfig.baseImage,
         PROJECT_DIR: `${projectMetadata.parentDirName}/`,
         PROJECT: projectMetadata.projectName,
+        IMAGE_TAG: '20260101-001-abc1234',
       })
     })
     it('should not set cacheRef', () => {
       expect(sut.cacheRef).toBeUndefined()
+    })
+  })
+
+  describe('with IMAGE_TAG env var set', () => {
+    const envTag = '20260601-042-dc38225'
+
+    beforeEach(() => {
+      process.env.IMAGE_TAG = envTag
+    })
+    afterEach(() => {
+      delete process.env.IMAGE_TAG
+    })
+
+    it('should prefer IMAGE_TAG env var over image ref tag', () => {
+      const sut = makeBuildSettings(image, dockerBuildConfig, projectMetadata)
+      expect(sut.buildArgs?.IMAGE_TAG).toBe(envTag)
     })
   })
 

--- a/scripts/docker-publish-sha.sh
+++ b/scripts/docker-publish-sha.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # Local usage:
-#   COMMIT_SHA=abc1234def5678 bash ./scripts/docker-publish-sha.sh
+#   COMMIT_SHA=abc1234def5678 RUN_NUMBER=42 bash ./scripts/docker-publish-sha.sh
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+RUN_NUMBER="${RUN_NUMBER:?RUN_NUMBER is required}"
 
 SHORT_SHA="${COMMIT_SHA::7}"
-export ABCTL_IMAGE_TAG="sha-${SHORT_SHA}"
+PADDED_RUN=$(printf '%03d' "$RUN_NUMBER")
+DATE=$(date +%Y%m%d)
 
-echo "Publishing app images with tag: ${ABCTL_IMAGE_TAG}"
+export ABCTL_IMAGE_TAG="sha-${SHORT_SHA}"
+export IMAGE_TAG="${DATE}-${PADDED_RUN}-${SHORT_SHA}"
+
+echo "Publishing app images with Docker tag: ${ABCTL_IMAGE_TAG} (IMAGE_TAG: ${IMAGE_TAG})"
 pnpm turbo run docker:publish --filter='./apps/*'

--- a/scripts/set-image-tag.sh
+++ b/scripts/set-image-tag.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 # Local usage:
-#   COMMIT_SHA=abc1234def5678 bash ./scripts/set-image-tag.sh
+#   COMMIT_SHA=abc1234def5678 RUN_NUMBER=42 bash ./scripts/set-image-tag.sh
 #
-# Computes IMAGE_TAG=sha-<sha7> from COMMIT_SHA and writes it to
-# $GITHUB_ENV (CI) or prints it (local). Matches the tag format
-# used by docker-publish-sha.sh so the value baked into next build
-# matches the pushed image tag.
+# Computes IMAGE_TAG=<YYYYMMDD>-<RRR>-<sha7> and writes it to
+# $GITHUB_ENV (CI) or prints it (local). Run number is zero-padded to
+# 3 digits. Matches the format used by docker-publish-sha.sh so the
+# value baked into next build matches the pushed image tag.
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+RUN_NUMBER="${RUN_NUMBER:?RUN_NUMBER is required}"
 
 SHORT_SHA="${COMMIT_SHA::7}"
-IMAGE_TAG="sha-${SHORT_SHA}"
+PADDED_RUN=$(printf '%03d' "$RUN_NUMBER")
+DATE=$(date +%Y%m%d)
+IMAGE_TAG="${DATE}-${PADDED_RUN}-${SHORT_SHA}"
 
 echo "IMAGE_TAG=${IMAGE_TAG}"
 

--- a/scripts/set-image-tag.sh
+++ b/scripts/set-image-tag.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Local usage:
+#   COMMIT_SHA=abc1234def5678 bash ./scripts/set-image-tag.sh
+#
+# Computes IMAGE_TAG=sha-<sha7> from COMMIT_SHA and writes it to
+# $GITHUB_ENV (CI) or prints it (local). Matches the tag format
+# used by docker-publish-sha.sh so the value baked into next build
+# matches the pushed image tag.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+
+SHORT_SHA="${COMMIT_SHA::7}"
+IMAGE_TAG="sha-${SHORT_SHA}"
+
+echo "IMAGE_TAG=${IMAGE_TAG}"
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
+fi

--- a/turbo.json
+++ b/turbo.json
@@ -45,6 +45,7 @@
     },
     "@abbottland/blog#build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "env": ["IMAGE_TAG"],
       "outputs": [".next/**"],
       "dependsOn": [
         "@abbottland/fui-components#build:npm",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalPassThroughEnv": ["CI", "ABCTL_IMAGE_TAG"],
+  "globalPassThroughEnv": ["CI", "ABCTL_IMAGE_TAG", "IMAGE_TAG"],
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],


### PR DESCRIPTION
## Summary

- Footer was always showing `dev` because `IMAGE_TAG` was never set during `next build`
- Home page is `'use client'` — `process.env` vars in client bundles must be inlined at build time via `next.config env` config
- Turbo was serving a cached `.next` output (with `dev` baked in) even when `IMAGE_TAG` changed, because it wasn't part of the cache key

## Changes

- **`apps/blog/next.config.mjs`** — expose `IMAGE_TAG` via `env` config so Next.js inlines it into the client bundle at build time
- **`docker/pnpm-turbo.Dockerfile`** — accept `ARG IMAGE_TAG` and set as env var before `turbo build` runs
- **`packages/abctl/.../docker-build-settings-builder.ts`** — pass `IMAGE_TAG` (extracted from image ref tag) as build arg when using `pnpm-turbo.Dockerfile`
- **`turbo.json`** — add `"env": ["IMAGE_TAG"]` to `@abbottland/blog#build` so the cache key changes per tag value
- **`scripts/set-image-tag.sh`** — new script that computes `sha-<sha7>` and writes to `$GITHUB_ENV`
- **`.github/workflows/ci.yml`** — call `set-image-tag.sh` before `pnpm build` so the artifact has the correct tag baked in

## Test plan

- [ ] CI passes
- [ ] After merge and deploy, footer shows `sha-<sha7>` instead of `dev`
- [ ] Subsequent builds with different SHA values produce cache misses and bake the new value correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)