### PR TITLE
feat: harbor-cleanup service, SHA-based image pipeline, and CI upgrades

### DIFF
--- a/.github/actions/pnpm-setup/action.yaml
+++ b/.github/actions/pnpm-setup/action.yaml
@@ -3,6 +3,10 @@ description: 'A composite action to run pnpm setup'
 runs:
   using: 'composite'
   steps:
+    - name: Install libatomic (required by pnpm/Node 26)
+      run: sudo apt-get update && sudo apt-get install -y libatomic1
+      shell: bash
+
     - name: Setup PNPM
       uses: pnpm/action-setup@v6
 
@@ -17,10 +21,6 @@ runs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/.nvmrc') }}
         restore-keys: |
           ${{ runner.os }}-node-
-
-    - name: Install libatomic (required by Node 26)
-      run: sudo apt-get update && sudo apt-get install -y libatomic1
-      shell: bash
 
     - name: Install Node.js
       uses: actions/setup-node@v4

--- a/.github/actions/pnpm-setup/action.yaml
+++ b/.github/actions/pnpm-setup/action.yaml
@@ -4,14 +4,14 @@ runs:
   using: 'composite'
   steps:
     - name: Setup PNPM
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Ensure Node.js directory exists
       run: mkdir -p ~/.nvm/versions/node
       shell: bash
 
     - name: Cache Node.js
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.nvm/versions/node
         key: ${{ runner.os }}-node-${{ hashFiles('**/.nvmrc') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [prod-gen2-amd64-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/pnpm-setup
@@ -49,7 +49,7 @@ jobs:
     runs-on: [prod-gen2-amd64-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/pnpm-setup
@@ -69,7 +69,7 @@ jobs:
     runs-on: [prod-gen2-amd64-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/pnpm-setup
@@ -114,7 +114,7 @@ jobs:
     runs-on: [prod-gen2-dind-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -169,7 +169,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -238,7 +238,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -302,7 +302,7 @@ jobs:
     runs-on: [prod-gen2-dind-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -334,7 +334,7 @@ jobs:
     runs-on: [prod-gen2-dind-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -381,7 +381,7 @@ jobs:
     runs-on: [prod-gen2-dind-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -453,7 +453,7 @@ jobs:
     runs-on: [prod-gen2-amd64-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [prod-gen2-dind-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/playwright-runner-publish.yml
+++ b/.github/workflows/playwright-runner-publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [prod-gen2-dind-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install jq
         uses: dcarbone/install-jq-action@v3.2.0

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: [prod-gen2-amd64-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install 1Password CLI
         uses: 1password/install-cli-action@v1

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [prod-gen2-dind-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@ next-env.d.ts
 
 packages/abctl/README.md
 packages/abctl/oclif.manifest.json
+
+claude-sessions/

--- a/apps/blog/src/components/MaskReveal/MaskReveal.tsx
+++ b/apps/blog/src/components/MaskReveal/MaskReveal.tsx
@@ -85,7 +85,7 @@ export default function MaskReveal({
         onComplete?.();
       },
     });
-  }, [reveal, duration, delay, direction, onComplete]);
+  }, [animated, reveal, duration, delay, direction, onComplete]);
 
   const isClipped = animated && phase === 'idle';
 

--- a/claude-sessions/2026-06-01-blog-footer-image-tag.md
+++ b/claude-sessions/2026-06-01-blog-footer-image-tag.md
@@ -1,0 +1,51 @@
+# 2026-06-01 — Blog Footer IMAGE_TAG Fix
+
+## Problem
+
+Footer of the live blog always showed `dev` instead of the deployed image tag. Pod was running `blog:20260601-21-dc38225` but footer read `dev`.
+
+## Root Cause Chain
+
+1. Home page is `'use client'` — `process.env` vars in client bundles must be inlined at build time, not read at runtime
+2. `next.config.mjs` had no `env` config, so `IMAGE_TAG` was never inlined
+3. CI `build` job ran `pnpm build` without `IMAGE_TAG` set → `'dev'` fallback baked in
+4. `IMAGE_TAG` was not in Turbo's cache key for `@abbottland/blog#build` → stale `dev` output reused across builds
+5. `docker-build-settings-builder.ts` didn't pass `IMAGE_TAG` as a Docker build arg
+
+## Fix (multiple PRs, all on `develop` → PR #107)
+
+### Tag format
+
+Changed from `sha-<sha7>` to `<YYYYMMDD>-<RRR>-<sha7>` (run number zero-padded to 3 digits, e.g. `20260601-021-dc38225`). This matches the production retag format and is human-readable.
+
+### Files changed
+
+| File | Change |
+|---|---|
+| `apps/blog/next.config.mjs` | Added `env: { IMAGE_TAG }` to inline at build time |
+| `docker/pnpm-turbo.Dockerfile` | Added `ARG IMAGE_TAG` / `ENV IMAGE_TAG` before `turbo build` |
+| `packages/abctl/.../docker-build-settings-builder.ts` | Prefer `process.env.IMAGE_TAG` over image ref tag extraction |
+| `packages/abctl/.../docker-build-settings-builder.unit.test.ts` | Updated tests for new behavior + added env override test case |
+| `turbo.json` | Added `"env": ["IMAGE_TAG"]` to `@abbottland/blog#build`; added `IMAGE_TAG` to `globalPassThroughEnv` |
+| `scripts/set-image-tag.sh` | New script: computes `YYYYMMDD-RRR-sha7`, writes to `$GITHUB_ENV` |
+| `scripts/docker-publish-sha.sh` | Accepts `RUN_NUMBER`, exports both `ABCTL_IMAGE_TAG=sha-<sha7>` and `IMAGE_TAG=YYYYMMDD-RRR-sha7` |
+| `.github/workflows/ci.yml` | Calls `set-image-tag.sh` before `pnpm build`; passes `RUN_NUMBER` to both scripts |
+| `docs/image-tag-footer-tracing.md` | New doc tracing full IMAGE_TAG flow end-to-end |
+
+### Key insight: Turbo cache
+
+`IMAGE_TAG` must be in `@abbottland/blog#build`'s `env` array so changing the SHA produces a cache miss. Without this, Turbo reuses the `dev`-baked `.next` output indefinitely.
+
+### Key insight: Docker build path
+
+In `docker-publish-sha.sh`, `IMAGE_TAG` is exported before `pnpm turbo run docker:publish`. `docker-build-settings-builder.ts` reads `process.env.IMAGE_TAG` and passes it as a Docker build arg. Turbo then hits the remote cache (same `IMAGE_TAG` as the CI `build` job) — no double bake.
+
+### Production behavior
+
+`docker-retag-prod.sh` retags `sha-<sha7>` → `YYYYMMDD-PRODRUN-sha7` without rebuilding. Footer keeps the CI-baked value (`YYYYMMDD-CIRUN-sha7`). Accepted trade-off — shows the build identity, not the exact prod tag.
+
+## Branch / PR
+
+- Branch: `develop`
+- PR: #107 (`develop` → `main`)
+- Also merged `feat/harbor-cleanup` (PR #106) into `main` during this session; resolved merge conflicts into `develop`


### PR DESCRIPTION
## Summary

- New `harbor-cleanup` Express service for automated container registry pruning, with cron scheduling and a `/status` endpoint
- Replaced floating changeset-based Docker tags with immutable `pr-<num>-<sha7>` tags throughout CI; blog footer now bakes `YYYYMMDD-RRR-sha7` at build time
- Extended Docker publish pipeline to all releasable apps (was blog-only)
- Fixed pnpm self-installer failure on self-hosted runners — `libatomic1` now installs before `pnpm/action-setup`
- Typography responsive scaling fixes and Storybook preview updates in `fui-components`

## Changes

**New service**
- `apps/harbor-cleanup/` — Express app using `@abbottland/express` + `yaml-config`; node-cron scheduled cleanup with throttled Harbor API calls (200ms/req); GitHub PAT sourced from 1Password

**CI / Docker**
- `.github/workflows/ci.yml` — SHA-based image tagging via `set-image-tag.sh`; Buildx configured with Harbor as pull-through mirror; disk prune before build; changeset check added
- `.github/workflows/docker-publish.yml` — publishes all releasable apps, not just blog
- `.github/workflows/update-snapshots.yml` — new `workflow_dispatch` to regenerate UI snapshots on failure
- `.github/actions/pnpm-setup/action.yaml` — `libatomic1` installs before pnpm setup (fixes exit 127)
- `scripts/set-image-tag.sh` — computes `YYYYMMDD-RRR-sha7`, writes to `$GITHUB_ENV`
- `scripts/docker-publish-sha.sh` — exports `IMAGE_TAG` alongside `ABCTL_IMAGE_TAG`
- `scripts/docker-retag-prod.sh` — new script for prod retag flow
- `refactor(ci)` — eliminated `docker-tag-pr`, deploy-preview uses sha tag directly

**Blog**
- `apps/blog/next.config.mjs` — inlines `IMAGE_TAG` at build time via `env` config
- `docker/pnpm-turbo.Dockerfile` — accepts `ARG IMAGE_TAG`, sets env before `turbo build`
- `turbo.json` — `IMAGE_TAG` added to blog build env cache key and `globalPassThroughEnv`
- `MaskReveal.tsx` — added `animated` to `useEffect` dep array

**fui-components**
- Typography responsive `h1`/`h2` scaling; removed `prose` dependency
- Storybook preview updates and new `TypographyShowcase` screenshot tests

**Packages**
- `packages/abctl` — prefer `process.env.IMAGE_TAG` over extracting from image ref

## Test plan

- [x] CI passes (lint, format, unit, integration, smoke, UI)
- [ ] After merge + deploy, blog footer shows `YYYYMMDD-RRR-sha7` instead of `dev`
- [ ] Harbor cleanup service deploys and cron runs without errors
- [ ] PR images use immutable `pr-<num>-<sha7>` tag in deploy preview