### PR TITLE
feat: system architecture diagrams, fui-icons expansion, and UI polish

### DIFF
--- a/apps/blog/src/app/system-architecture/ServiceComponentsTabs.tsx
+++ b/apps/blog/src/app/system-architecture/ServiceComponentsTabs.tsx
@@ -19,66 +19,79 @@ const tabs: {
   id: string;
   label: string;
   iconId: string;
+  borderColor?: string;
   data: DiagramViewerProps['data'];
 }[] = [
-  {
-    id: 'lan-ingress',
-    label: 'LAN Ingress Pattern',
-    iconId: 'radix-paper-plane',
-    data: lanIngressData as DiagramViewerProps['data'],
-  },
   {
     id: 'public-ingress',
     label: 'Public Ingress Pattern',
     iconId: 'radix-paper-plane',
+    borderColor: 'border-accent-falcon-600',
     data: publicIngressData as DiagramViewerProps['data'],
   },
   {
-    id: 'developer-experience',
-    label: 'Developer Experience',
-    iconId: 'radix-code',
-    data: developerExperienceData as DiagramViewerProps['data'],
+    id: 'lan-ingress',
+    label: 'LAN Ingress Pattern',
+    iconId: 'radix-paper-plane',
+    borderColor: 'border-accent-falcon-600',
+    data: lanIngressData as DiagramViewerProps['data'],
   },
   {
     id: 'virtualization',
     label: 'Virtualization',
     iconId: 'radix-card-stack',
+    borderColor: 'border-warning-500',
     data: virtualizationData as DiagramViewerProps['data'],
   },
   {
     id: 'storage',
     label: 'Storage',
     iconId: 'cylinder',
+    borderColor: 'border-warning-500',
     data: storageData as DiagramViewerProps['data'],
+  },
+  {
+    id: 'developer-experience',
+    label: 'Developer Experience',
+    iconId: 'radix-code',
+    borderColor: 'border-warning-500',
+    data: developerExperienceData as DiagramViewerProps['data'],
   },
   {
     id: 'monitoring',
     label: 'Monitoring',
     iconId: 'radix-eye-open',
+    borderColor: 'border-secondary-600',
     data: monitoringData as DiagramViewerProps['data'],
   },
   {
     id: 'media-stack',
     label: 'Media Stack',
     iconId: 'radix-mixer',
+    borderColor: 'border-primary-600',
     data: mediaStackData as DiagramViewerProps['data'],
   },
   {
     id: 'custom-app-pipeline',
     label: 'Custom Application Deployment Pipeline',
     iconId: 'radix-code',
+    borderColor: 'border-accent-purple-500',
     data: customAppPipelineData as DiagramViewerProps['data'],
   },
   {
     id: 'gitops-pipeline',
     label: 'GitOps Deployment Pipeline',
     iconId: 'radix-upload',
+    borderColor: 'border-accent-purple-500',
     data: gitopsPipelineData as DiagramViewerProps['data'],
   },
 ];
 
-const triggerClass =
-  'px-3 py-2 text-left cursor-pointer transition-colors hover:bg-neutral-700/50 data-[state=active]:bg-neutral-800 data-[state=active]:shadow-sm leading-none';
+const baseTriggerClass =
+  'px-3 py-2 text-left cursor-pointer transition-colors border hover:bg-neutral-700/50 data-[state=active]:bg-neutral-800 data-[state=active]:shadow-sm leading-none';
+
+const getTriggerClass = (borderColor?: string) =>
+  `${baseTriggerClass} ${borderColor ?? 'border-neutral-700'}`;
 
 export function ServiceComponentsTabs() {
   return (
@@ -89,7 +102,11 @@ export function ServiceComponentsTabs() {
     >
       <Tabs.List className="flex w-44 flex-col border-r border-neutral-700 bg-neutral-800/40 p-2 gap-0.5 shrink-0">
         {tabs.map((tab) => (
-          <Tabs.Trigger key={tab.id} value={tab.id} className={triggerClass}>
+          <Tabs.Trigger
+            key={tab.id}
+            value={tab.id}
+            className={getTriggerClass(tab.borderColor)}
+          >
             <span className="flex items-center gap-2">
               <Icon name={tab.iconId} size={16} className="shrink-0" />
               <Typography variant="body2" component="span">

--- a/apps/blog/src/app/system-architecture/diagram-02.json
+++ b/apps/blog/src/app/system-architecture/diagram-02.json
@@ -4,20 +4,94 @@
       "id": "node_9",
       "type": "labeled",
       "position": {
-        "x": 221.59961930240547,
-        "y": 144.31637697967997
+        "x": 188.25498653404392,
+        "y": 129.31438574000052
       },
       "data": {
         "label": "My House",
         "content": "",
         "iconId": "radix-home",
-        "width": 691,
-        "height": 537,
-        "colorScheme": "dark"
+        "width": 974,
+        "height": 585,
+        "colorScheme": "default"
       },
       "measured": {
-        "width": 691,
-        "height": 537
+        "width": 974,
+        "height": 585
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_21",
+      "type": "labeled",
+      "position": {
+        "x": 201.32603743483594,
+        "y": 165.2480730759513
+      },
+      "data": {
+        "label": "Ingress",
+        "content": "",
+        "colorScheme": "accent-falcon",
+        "width": 224,
+        "height": 374
+      },
+      "measured": {
+        "width": 224,
+        "height": 374
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_20",
+      "type": "labeled",
+      "position": {
+        "x": 921.0815155098392,
+        "y": 165.8893160138044
+      },
+      "data": {
+        "label": "CI/CD",
+        "content": "",
+        "colorScheme": "accent-purple",
+        "width": 231,
+        "height": 374
+      },
+      "measured": {
+        "width": 231,
+        "height": 374
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_19",
+      "type": "labeled",
+      "position": {
+        "x": 435.20705768069075,
+        "y": 578.0435526027104
+      },
+      "data": {
+        "label": "Virtualization Platform",
+        "content": "",
+        "width": 501,
+        "height": 125,
+        "colorScheme": "warning",
+        "iconId": "proxmox",
+        "handles": [
+          {
+            "id": "handle-1780667875271",
+            "type": "source",
+            "position": "top"
+          }
+        ]
+      },
+      "measured": {
+        "width": 501,
+        "height": 125
       },
       "selected": false,
       "dragging": false,
@@ -27,27 +101,21 @@
       "id": "node_13",
       "type": "labeled",
       "position": {
-        "x": 437.4210266471535,
-        "y": 166.0634663394507
+        "x": 434.21481195788783,
+        "y": 165.42222340159762
       },
       "data": {
         "label": "Kubernetes Cluster",
         "content": "",
         "iconId": "kubernetes",
         "colorScheme": "secondary",
-        "width": 446,
-        "height": 404,
-        "handles": [
-          {
-            "id": "handle-1780537453534",
-            "type": "target",
-            "position": "bottom"
-          }
-        ]
+        "width": 479,
+        "height": 375,
+        "handles": []
       },
       "measured": {
-        "width": 446,
-        "height": 404
+        "width": 479,
+        "height": 375
       },
       "selected": false,
       "dragging": false,
@@ -57,13 +125,13 @@
       "id": "node_0",
       "type": "labeled",
       "position": {
-        "x": 502.8436611485838,
-        "y": 201.75235854161545
+        "x": 507.28628394305406,
+        "y": 210.18451812387784
       },
       "data": {
         "content": "",
         "label": "Web Applications",
-        "width": 209,
+        "width": 203,
         "height": 298,
         "handles": [
           {
@@ -77,16 +145,16 @@
             "position": "right"
           },
           {
-            "id": "handle-1780537558099",
+            "id": "handle-1780669285560",
             "type": "target",
             "position": "bottom"
           }
         ],
-        "colorScheme": "default",
+        "colorScheme": "primary",
         "iconId": "radix-globe"
       },
       "measured": {
-        "width": 209,
+        "width": 203,
         "height": 298
       },
       "selected": false,
@@ -97,8 +165,8 @@
       "id": "node_1",
       "type": "customDefault",
       "position": {
-        "x": 775.0821292711745,
-        "y": 378.14763419892836
+        "x": 931.3550759526249,
+        "y": 277.8641096671558
       },
       "data": {
         "content": "Custom Application Deployment Pipeline",
@@ -125,18 +193,12 @@
       "id": "node_2",
       "type": "customDefault",
       "position": {
-        "x": 259.4858625003957,
-        "y": 501.83965159965544
+        "x": 764.9644485016904,
+        "y": 610.8353779218202
       },
       "data": {
         "content": "Developer Experience",
-        "handles": [
-          {
-            "id": "handle-1780535866245",
-            "type": "source",
-            "position": "right"
-          }
-        ],
+        "handles": [],
         "iconId": "radix-code"
       },
       "measured": {
@@ -150,8 +212,8 @@
       "id": "node_3",
       "type": "customDefault",
       "position": {
-        "x": 725.2886531573616,
-        "y": 203.70074020895294
+        "x": 746.6178437145446,
+        "y": 206.64269752718508
       },
       "data": {
         "content": "Monitoring",
@@ -175,30 +237,30 @@
       "id": "node_5",
       "type": "customDefault",
       "position": {
-        "x": 237.45452133524822,
-        "y": 310.9289265303727
+        "x": 226.09645953589865,
+        "y": 367.47353569746235
       },
       "data": {
         "content": "LAN Ingress Pattern",
         "handles": [
           {
-            "id": "handle-1780536008387",
-            "type": "target",
-            "position": "top"
-          },
-          {
             "id": "handle-1780536008531",
             "type": "source",
             "position": "right"
+          },
+          {
+            "id": "handle-1780667688450",
+            "type": "target",
+            "position": "bottom"
           }
         ],
-        "width": 213,
+        "width": 183,
         "height": 80,
         "colorScheme": "default",
         "iconId": "radix-paper-plane"
       },
       "measured": {
-        "width": 213,
+        "width": 183,
         "height": 80
       },
       "selected": false,
@@ -209,8 +271,8 @@
       "id": "node_6",
       "type": "customDefault",
       "position": {
-        "x": -35.7130468856481,
-        "y": 411.94267950296256
+        "x": -23.04845611122728,
+        "y": 238.38942092917716
       },
       "data": {
         "content": "End User\n(You)",
@@ -235,8 +297,8 @@
       "id": "node_7",
       "type": "customDefault",
       "position": {
-        "x": 172.14587113174878,
-        "y": 411.67542875491597
+        "x": 222.0975856874701,
+        "y": 238.45209923200417
       },
       "data": {
         "content": "Public Ingress Pattern",
@@ -252,13 +314,13 @@
             "position": "right"
           }
         ],
-        "width": 279,
+        "width": 187,
         "height": 80,
         "colorScheme": "default",
         "iconId": "radix-paper-plane"
       },
       "measured": {
-        "width": 279,
+        "width": 187,
         "height": 80
       },
       "selected": false,
@@ -269,8 +331,8 @@
       "id": "node_8",
       "type": "customDefault",
       "position": {
-        "x": 268.7489802306247,
-        "y": 181.03901296707613
+        "x": 242.37634915440032,
+        "y": 575.0043931171274
       },
       "data": {
         "content": "LAN Users\n(Me)",
@@ -279,9 +341,10 @@
           {
             "id": "handle-1780536182444",
             "type": "source",
-            "position": "bottom"
+            "position": "top"
           }
-        ]
+        ],
+        "colorScheme": "default"
       },
       "measured": {
         "width": 150,
@@ -294,18 +357,12 @@
       "id": "node_10",
       "type": "customDefault",
       "position": {
-        "x": 461.72407209017905,
-        "y": 585.3440189479238
+        "x": 449.0311721781463,
+        "y": 610.1770720621239
       },
       "data": {
         "content": "Virtualization",
-        "handles": [
-          {
-            "id": "handle-1780536462048",
-            "type": "source",
-            "position": "right"
-          }
-        ],
+        "handles": [],
         "iconId": "radix-card-stack"
       },
       "measured": {
@@ -319,18 +376,12 @@
       "id": "node_11",
       "type": "customDefault",
       "position": {
-        "x": 709.2986346737533,
-        "y": 584.8227078847067
+        "x": 607.0142185539704,
+        "y": 611.1093909239268
       },
       "data": {
         "content": "Storage",
-        "handles": [
-          {
-            "id": "handle-1780536469693",
-            "type": "source",
-            "position": "left"
-          }
-        ],
+        "handles": [],
         "iconId": "cylinder"
       },
       "measured": {
@@ -344,8 +395,8 @@
       "id": "node_4",
       "type": "customDefault",
       "position": {
-        "x": 532.9822432145975,
-        "y": 237.26872696970872
+        "x": 533.8110950566286,
+        "y": 330.82486955953584
       },
       "data": {
         "content": "Media Stack",
@@ -365,21 +416,15 @@
       "id": "node_12",
       "type": "customDefault",
       "position": {
-        "x": 531.8669448243309,
-        "y": 411.77217484156677
+        "x": 532.5542655326856,
+        "y": 242.69128058631634
       },
       "data": {
         "content": "Blog Website",
         "iconId": "radix-globe",
         "width": 161,
         "height": 80,
-        "handles": [
-          {
-            "id": "handle-1780537999741",
-            "type": "target",
-            "position": "left"
-          }
-        ]
+        "handles": []
       },
       "measured": {
         "width": 161,
@@ -393,11 +438,11 @@
       "id": "node_17",
       "type": "customDefault",
       "position": {
-        "x": 531.5172607150798,
-        "y": 325.96891637413927
+        "x": 533.7611696480891,
+        "y": 415.7252736945102
       },
       "data": {
-        "content": "Other Applications",
+        "content": "Other Apps & Services",
         "width": 162,
         "height": 80,
         "iconId": "radix-component"
@@ -414,8 +459,8 @@
       "id": "node_18",
       "type": "customDefault",
       "position": {
-        "x": 775.5821081799273,
-        "y": 467.1276314329653
+        "x": 932.5980546077452,
+        "y": 365.9993503463111
       },
       "data": {
         "content": "GitOps deployment Pipeline",
@@ -509,66 +554,6 @@
       "markerEnd": {
         "type": "arrowclosed"
       },
-      "source": "node_8",
-      "sourceHandle": "handle-1780536182444",
-      "target": "node_5",
-      "targetHandle": "handle-1780536008387",
-      "id": "xy-edge__node_8handle-1780536182444-node_5handle-1780536008387",
-      "selected": false,
-      "zIndex": 20,
-      "data": {
-        "active": true
-      }
-    },
-    {
-      "type": "basic",
-      "style": {
-        "stroke": "#C8D9DE",
-        "strokeWidth": 2
-      },
-      "markerEnd": {
-        "type": "arrowclosed"
-      },
-      "source": "node_10",
-      "sourceHandle": "handle-1780536462048",
-      "target": "node_13",
-      "targetHandle": "handle-1780537453534",
-      "id": "xy-edge__node_10handle-1780536462048-node_13handle-1780537453534",
-      "selected": false,
-      "zIndex": 20,
-      "data": {
-        "active": true
-      }
-    },
-    {
-      "type": "basic",
-      "style": {
-        "stroke": "#C8D9DE",
-        "strokeWidth": 2
-      },
-      "markerEnd": {
-        "type": "arrowclosed"
-      },
-      "source": "node_11",
-      "sourceHandle": "handle-1780536469693",
-      "target": "node_13",
-      "targetHandle": "handle-1780537453534",
-      "id": "xy-edge__node_11handle-1780536469693-node_13handle-1780537453534",
-      "selected": false,
-      "zIndex": 20,
-      "data": {
-        "active": true
-      }
-    },
-    {
-      "type": "basic",
-      "style": {
-        "stroke": "#C8D9DE",
-        "strokeWidth": 2
-      },
-      "markerEnd": {
-        "type": "arrowclosed"
-      },
       "source": "node_1",
       "sourceHandle": "handle-1780535916662",
       "target": "node_0",
@@ -629,46 +614,6 @@
       "markerEnd": {
         "type": "arrowclosed"
       },
-      "source": "node_7",
-      "sourceHandle": "handle-1780536048818",
-      "target": "node_12",
-      "targetHandle": "handle-1780537999741",
-      "id": "xy-edge__node_7handle-1780536048818-node_12handle-1780537999741",
-      "selected": false,
-      "zIndex": 20,
-      "data": {
-        "active": true
-      }
-    },
-    {
-      "type": "basic",
-      "style": {
-        "stroke": "#C8D9DE",
-        "strokeWidth": 2
-      },
-      "markerEnd": {
-        "type": "arrowclosed"
-      },
-      "source": "node_2",
-      "sourceHandle": "handle-1780535866245",
-      "target": "node_0",
-      "targetHandle": "handle-1780537558099",
-      "id": "xy-edge__node_2handle-1780535866245-node_0handle-1780537558099",
-      "selected": false,
-      "zIndex": 20,
-      "data": {
-        "active": true
-      }
-    },
-    {
-      "type": "basic",
-      "style": {
-        "stroke": "#C8D9DE",
-        "strokeWidth": 2
-      },
-      "markerEnd": {
-        "type": "arrowclosed"
-      },
       "source": "node_18",
       "sourceHandle": "handle-1780538556251",
       "target": "node_0",
@@ -679,7 +624,62 @@
       "data": {
         "active": true
       }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_7",
+      "sourceHandle": "handle-1780536048818",
+      "target": "node_0",
+      "targetHandle": "handle-1780535765386",
+      "id": "xy-edge__node_7handle-1780536048818-node_0handle-1780535765386"
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_8",
+      "sourceHandle": "handle-1780536182444",
+      "target": "node_5",
+      "targetHandle": "handle-1780667688450",
+      "id": "xy-edge__node_8handle-1780536182444-node_5handle-1780667688450",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_19",
+      "sourceHandle": "handle-1780667875271",
+      "target": "node_0",
+      "targetHandle": "handle-1780669285560",
+      "id": "xy-edge__node_19handle-1780667875271-node_0handle-1780669285560",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
     }
   ],
-  "isComplete": false
+  "isComplete": true
 }

--- a/apps/blog/src/app/system-architecture/diagram-c3-virtualization.json
+++ b/apps/blog/src/app/system-architecture/diagram-c3-virtualization.json
@@ -2,13 +2,1353 @@
   "nodes": [
     {
       "id": "node_0",
+      "type": "labeled",
+      "position": {
+        "x": -443.3242374618665,
+        "y": -125.15713674935752
+      },
+      "data": {
+        "label": "Proxmox",
+        "content": "",
+        "iconId": "proxmox",
+        "width": 2487,
+        "height": 865,
+        "colorScheme": "warning"
+      },
+      "measured": {
+        "width": 2487,
+        "height": 865
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_30",
+      "type": "labeled",
+      "position": {
+        "x": -425.55278566407924,
+        "y": 103.32857462489983
+      },
+      "data": {
+        "content": "",
+        "iconId": "hard-drive",
+        "colorScheme": "primary",
+        "label": "Secondary SATA SSD (2TB)",
+        "width": 288,
+        "height": 242
+      },
+      "measured": {
+        "width": 288,
+        "height": 242
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_7",
+      "type": "labeled",
+      "position": {
+        "x": 386.9258343028339,
+        "y": 83.61715981093172
+      },
+      "data": {
+        "label": "Virtual Machines",
+        "content": "",
+        "colorScheme": "secondary",
+        "width": 916,
+        "height": 469,
+        "handles": [
+          {
+            "id": "handle-1780840954837",
+            "type": "target",
+            "position": "right"
+          },
+          {
+            "id": "handle-1781059004236",
+            "type": "target",
+            "position": "left"
+          },
+          {
+            "id": "handle-1781059080744",
+            "type": "target",
+            "position": "top"
+          }
+        ]
+      },
+      "measured": {
+        "width": 916,
+        "height": 469
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_12",
+      "type": "labeled",
+      "position": {
+        "x": 402.9239039918331,
+        "y": 122.09976093299818
+      },
+      "data": {
+        "label": "Kubernetes Prod",
+        "content": "",
+        "width": 278,
+        "height": 394,
+        "iconId": "kubernetes",
+        "handles": []
+      },
+      "measured": {
+        "width": 278,
+        "height": 394
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_1",
+      "type": "labeled",
+      "position": {
+        "x": 1395.3195079107732,
+        "y": 85.39573813384082
+      },
+      "data": {
+        "label": "local-lvm",
+        "content": "",
+        "colorScheme": "warning",
+        "iconId": "cylinder",
+        "width": 256,
+        "height": 466,
+        "handles": [
+          {
+            "id": "handle-1780840814117",
+            "type": "target",
+            "position": "right"
+          },
+          {
+            "id": "handle-1780840963845",
+            "type": "source",
+            "position": "left"
+          }
+        ]
+      },
+      "measured": {
+        "width": 256,
+        "height": 466
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_2",
+      "type": "text",
+      "position": {
+        "x": 1408.2653985507247,
+        "y": 118.51721014492767
+      },
+      "data": {
+        "content": "Each VM gets a -disk-0 \nand a -cloudinit disk\n(930.5GB)"
+      },
+      "measured": {
+        "width": 230,
+        "height": 77
+      },
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node_4",
+      "type": "labeled",
+      "position": {
+        "x": 899.7289325983364,
+        "y": -102.90958009396422
+      },
+      "data": {
+        "label": "VM Template",
+        "content": "",
+        "iconId": "radix-stack",
+        "colorScheme": "secondary",
+        "width": 253,
+        "height": 139,
+        "handles": [
+          {
+            "id": "handle-1781059130833",
+            "type": "target",
+            "position": "right"
+          },
+          {
+            "id": "handle-1781059131386",
+            "type": "source",
+            "position": "left"
+          }
+        ]
+      },
+      "measured": {
+        "width": 253,
+        "height": 139
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_5",
       "type": "customDefault",
-      "position": { "x": 1006.5, "y": 461.109375 },
-      "data": { "content": "Virtualization" },
-      "measured": { "width": 150, "height": 80 },
+      "position": {
+        "x": 922.7289325983364,
+        "y": -76.40958009396421
+      },
+      "data": {
+        "content": "ansible-template-ubuntu-noble",
+        "iconId": "radix-desktop",
+        "width": 201,
+        "height": 80
+      },
+      "measured": {
+        "width": 201,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_6",
+      "type": "labeled",
+      "position": {
+        "x": 1396.8321267429906,
+        "y": 575.2365642679563
+      },
+      "data": {
+        "label": "Local",
+        "content": "Storage for the Proxmox Host Operating System.  (100GB)",
+        "iconId": "cylinder",
+        "colorScheme": "warning",
+        "width": 256,
+        "height": 146,
+        "handles": [
+          {
+            "id": "handle-1780840805969",
+            "type": "target",
+            "position": "right"
+          }
+        ]
+      },
+      "measured": {
+        "width": 256,
+        "height": 146
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_8",
+      "type": "customDefault",
+      "position": {
+        "x": 412.4348621949242,
+        "y": 151.45082005849073
+      },
+      "data": {
+        "content": "tf-prod-k8s-controller-1\n(#204) 192.168.6.24",
+        "iconId": "radix-desktop",
+        "width": 253,
+        "height": 80
+      },
+      "measured": {
+        "width": 253,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_9",
+      "type": "customDefault",
+      "position": {
+        "x": 413.0946161503108,
+        "y": 239.85785008027463
+      },
+      "data": {
+        "content": "tf-prod-k8s-worker-1\n(#205) 192.168.6.25",
+        "iconId": "radix-desktop",
+        "width": 253,
+        "height": 80
+      },
+      "measured": {
+        "width": 253,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_10",
+      "type": "customDefault",
+      "position": {
+        "x": 415.0738780164701,
+        "y": 329.5843880128315
+      },
+      "data": {
+        "content": "tf-prod-k8s-worker-2\n(#206) 192.168.6.26",
+        "width": 250,
+        "height": 80,
+        "iconId": "radix-desktop"
+      },
+      "measured": {
+        "width": 250,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_11",
+      "type": "customDefault",
+      "position": {
+        "x": 413.0946161503107,
+        "y": 418.65117199000167
+      },
+      "data": {
+        "content": "tf-prod-k8s-worker-3 \n(#207) 192.168.6.27",
+        "width": 252,
+        "height": 80,
+        "iconId": "radix-desktop"
+      },
+      "measured": {
+        "width": 252,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_13",
+      "type": "labeled",
+      "position": {
+        "x": 693.1613881690208,
+        "y": 122.20194380620231
+      },
+      "data": {
+        "label": "Kubernetes non-prod",
+        "content": "",
+        "iconId": "kubernetes",
+        "width": 310,
+        "height": 393
+      },
+      "measured": {
+        "width": 310,
+        "height": 393
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_14",
+      "type": "customDefault",
+      "position": {
+        "x": 708.8749206227661,
+        "y": 155.3376580742379
+      },
+      "data": {
+        "content": "tf-nonprod-k8s-controller-1\n(#301) 192.168.6.31",
+        "width": 277,
+        "height": 80,
+        "iconId": "radix-desktop"
+      },
+      "measured": {
+        "width": 277,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_15",
+      "type": "customDefault",
+      "position": {
+        "x": 708.874920622766,
+        "y": 243.33765807423802
+      },
+      "data": {
+        "content": "tf-nonprod-k8s-worker-1\n(#301) 192.168.6.32",
+        "width": 279,
+        "height": 80,
+        "iconId": "radix-desktop"
+      },
+      "measured": {
+        "width": 279,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_17",
+      "type": "customDefault",
+      "position": {
+        "x": 708.8749206227661,
+        "y": 331.337658074238
+      },
+      "data": {
+        "content": "tf-nonprod-k8s-worker-2\n(#302) 192.168.6.33",
+        "width": 279,
+        "height": 80,
+        "iconId": "radix-desktop"
+      },
+      "measured": {
+        "width": 279,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_18",
+      "type": "customDefault",
+      "position": {
+        "x": 705.874920622766,
+        "y": 420.337658074238
+      },
+      "data": {
+        "content": "tf-nonprod-k8s-worker-3\n(#303) 192.168.6.34",
+        "width": 282,
+        "height": 80,
+        "iconId": "radix-desktop"
+      },
+      "measured": {
+        "width": 282,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_20",
+      "type": "labeled",
+      "position": {
+        "x": 1026.3455483939965,
+        "y": 122.99837213225382
+      },
+      "data": {
+        "label": "Developer Jumpbox",
+        "content": "",
+        "width": 256,
+        "height": 122,
+        "iconId": "radix-code"
+      },
+      "measured": {
+        "width": 256,
+        "height": 122
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_21",
+      "type": "customDefault",
+      "position": {
+        "x": 1034.3455483939965,
+        "y": 156.99837213225382
+      },
+      "data": {
+        "content": "marauders-map\n(500) 192.168.5.91 (DHCP)",
+        "iconId": "radix-desktop",
+        "width": 241,
+        "height": 80
+      },
+      "measured": {
+        "width": 241,
+        "height": 80
+      },
+      "selected": false,
+      "resizing": false,
+      "dragging": false
+    },
+    {
+      "id": "node_22",
+      "type": "customDefault",
+      "position": {
+        "x": 1414.4404871568345,
+        "y": 206.35917921983912
+      },
+      "data": {
+        "content": "",
+        "width": 192,
+        "height": 85,
+        "iconId": "hard-drive"
+      },
+      "measured": {
+        "width": 192,
+        "height": 85
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_23",
+      "type": "customDefault",
+      "position": {
+        "x": 1415.4051610698775,
+        "y": 338.5321864662159
+      },
+      "data": {
+        "content": "",
+        "width": 173,
+        "height": 80
+      },
+      "measured": {
+        "width": 173,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_24",
+      "type": "customDefault",
+      "position": {
+        "x": 1422.0944726640805,
+        "y": 216.30936037925932
+      },
+      "data": {
+        "content": "",
+        "iconId": "hard-drive",
+        "width": 192,
+        "height": 80
+      },
+      "measured": {
+        "width": 192,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_25",
+      "type": "customDefault",
+      "position": {
+        "x": 1430.5138567220517,
+        "y": 227.79033864012888
+      },
+      "data": {
+        "content": "vm-204-cloud-init (4.19MB)",
+        "width": 192,
+        "height": 83,
+        "iconId": "hard-drive"
+      },
+      "measured": {
+        "width": 192,
+        "height": 83
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_26",
+      "type": "customDefault",
+      "position": {
+        "x": 1426.0926610698777,
+        "y": 348.44432414737526
+      },
+      "data": {
+        "content": "",
+        "width": 172,
+        "height": 80
+      },
+      "measured": {
+        "width": 172,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_27",
+      "type": "customDefault",
+      "position": {
+        "x": 1436.1470088959647,
+        "y": 360.32022994447675
+      },
+      "data": {
+        "content": "vm-204-disk-0\n(34.36GB)",
+        "iconId": "hard-drive",
+        "width": 176,
+        "height": 80
+      },
+      "measured": {
+        "width": 176,
+        "height": 80
+      },
+      "selected": false,
+      "resizing": false,
+      "dragging": false
+    },
+    {
+      "id": "node_28",
+      "type": "labeled",
+      "position": {
+        "x": 1765.812356914022,
+        "y": 382.27757306735407
+      },
+      "data": {
+        "content": "",
+        "iconId": "hard-drive",
+        "colorScheme": "primary",
+        "width": 248,
+        "height": 157,
+        "handles": [
+          {
+            "id": "handle-1780840798000",
+            "type": "source",
+            "position": "left"
+          }
+        ],
+        "label": "Onboard Storage\nNVME SSD (1TB)"
+      },
+      "measured": {
+        "width": 248,
+        "height": 157
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_29",
+      "type": "labeled",
+      "position": {
+        "x": 216.21162458263612,
+        "y": -323.6263725633581
+      },
+      "data": {
+        "label": "pbabbott/home-playbooks",
+        "content": "",
+        "iconId": "github",
+        "width": 1198,
+        "height": 183,
+        "colorScheme": "dark"
+      },
+      "measured": {
+        "width": 1198,
+        "height": 183
+      },
+      "selected": false,
+      "resizing": false,
+      "dragging": false
+    },
+    {
+      "id": "node_31",
+      "type": "labeled",
+      "position": {
+        "x": -12.425477235772874,
+        "y": 112.76538612729652
+      },
+      "data": {
+        "label": "etcd-ssd",
+        "content": "",
+        "colorScheme": "warning",
+        "width": 242,
+        "height": 180,
+        "handles": [
+          {
+            "id": "handle-1781058908141",
+            "type": "target",
+            "position": "left"
+          },
+          {
+            "id": "handle-1781059010601",
+            "type": "source",
+            "position": "right"
+          }
+        ]
+      },
+      "measured": {
+        "width": 242,
+        "height": 180
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_32",
+      "type": "labeled",
+      "position": {
+        "x": -15.49539681069875,
+        "y": 312.74830601189444
+      },
+      "data": {
+        "label": "fast-ssd",
+        "content": "",
+        "colorScheme": "warning",
+        "width": 247,
+        "height": 216,
+        "handles": [
+          {
+            "id": "handle-1781058923491",
+            "type": "target",
+            "position": "left"
+          },
+          {
+            "id": "handle-1781059015794",
+            "type": "source",
+            "position": "right"
+          }
+        ]
+      },
+      "measured": {
+        "width": 247,
+        "height": 216
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_34",
+      "type": "labeled",
+      "position": {
+        "x": 616.7766250925274,
+        "y": -288.8141784497784
+      },
+      "data": {
+        "label": "playbooks",
+        "content": "",
+        "iconId": "ansible",
+        "width": 758,
+        "height": 131
+      },
+      "measured": {
+        "width": 758,
+        "height": 131
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_33",
+      "type": "labeled",
+      "position": {
+        "x": 1041.7978200799057,
+        "y": -251.14184525771537
+      },
+      "data": {
+        "content": "Configures template and finalizes it in proxmox",
+        "width": 299,
+        "height": 80,
+        "iconId": "ansible",
+        "label": "ansible-template-ubuntu-noble",
+        "handles": [
+          {
+            "id": "handle-1781059139069",
+            "type": "source",
+            "position": "bottom"
+          }
+        ]
+      },
+      "measured": {
+        "width": 299,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_35",
+      "type": "labeled",
+      "position": {
+        "x": 269.9979682732799,
+        "y": -283.43349464249866
+      },
+      "data": {
+        "label": "terraform",
+        "content": "Provisions Prod & Non-prod fleet in proxmox",
+        "iconId": "terraform",
+        "width": 311,
+        "height": 119,
+        "handles": [
+          {
+            "id": "handle-1781059060807",
+            "type": "source",
+            "position": "bottom"
+          }
+        ]
+      },
+      "measured": {
+        "width": 311,
+        "height": 119
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_38",
+      "type": "labeled",
+      "position": {
+        "x": 661.210659113935,
+        "y": -250.5909477571103
+      },
+      "data": {
+        "label": "kubernetes-gen2",
+        "content": "Installs kubernetes onto target hosts",
+        "iconId": "ansible",
+        "width": 355,
+        "height": 80,
+        "handles": [
+          {
+            "id": "handle-1781059056066",
+            "type": "source",
+            "position": "bottom"
+          }
+        ]
+      },
+      "measured": {
+        "width": 355,
+        "height": 80
+      },
+      "selected": false,
+      "resizing": false,
+      "dragging": false
+    },
+    {
+      "id": "node_41",
+      "type": "text",
+      "position": {
+        "x": -77.037046726195,
+        "y": -13.021441515405165
+      },
+      "data": {
+        "content": "TODO: Need to clean up these \ndisks. Only 2 are needed (1 per \netcd instance), but there's 1 \nper vm. 7*22GB=154GB wasted \nspace",
+        "colorScheme": "error"
+      },
+      "measured": {
+        "width": 306,
+        "height": 128
+      },
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node_42",
+      "type": "customDefault",
+      "position": {
+        "x": 8.922273031701948,
+        "y": 155.42296457648592
+      },
+      "data": {
+        "content": "",
+        "width": 168,
+        "height": 80
+      },
+      "measured": {
+        "width": 168,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_43",
+      "type": "customDefault",
+      "position": {
+        "x": 16.92227303170195,
+        "y": 164.92296457648592
+      },
+      "data": {
+        "content": "",
+        "width": 170,
+        "height": 80
+      },
+      "measured": {
+        "width": 170,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_44",
+      "type": "customDefault",
+      "position": {
+        "x": 24.42227303170192,
+        "y": 174.42296457648592
+      },
+      "data": {
+        "content": "vm-204-disk-0\n(21GB each)",
+        "iconId": "hard-drive",
+        "width": 173,
+        "height": 81,
+        "handles": []
+      },
+      "measured": {
+        "width": 173,
+        "height": 81
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_46",
+      "type": "customDefault",
+      "position": {
+        "x": 0.33118010780320617,
+        "y": 343.3930919749042
+      },
+      "data": {
+        "content": "",
+        "width": 189,
+        "height": 80
+      },
+      "measured": {
+        "width": 189,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_47",
+      "type": "customDefault",
+      "position": {
+        "x": 10.887243393986338,
+        "y": 353.9491552610874
+      },
+      "data": {
+        "content": "",
+        "width": 186,
+        "height": 80
+      },
+      "measured": {
+        "width": 186,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_48",
+      "type": "customDefault",
+      "position": {
+        "x": 24.082322501715268,
+        "y": 370.44300414574866
+      },
+      "data": {
+        "content": "vm-204-disk-0\n(275GB)",
+        "width": 186,
+        "height": 80,
+        "iconId": "hard-drive"
+      },
+      "measured": {
+        "width": 186,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_50",
+      "type": "text",
+      "position": {
+        "x": -0.6863613843810299,
+        "y": 469.36023224654616
+      },
+      "data": {
+        "content": "/dev/sdb -> /mnt/ssd"
+      },
+      "measured": {
+        "width": 214,
+        "height": 26
+      },
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node_51",
+      "type": "text",
+      "position": {
+        "x": -4.1324564493720715,
+        "y": 260.2971316370858
+      },
+      "data": {
+        "content": "/dev/sdc -> /mnt/etcd"
+      },
+      "measured": {
+        "width": 224,
+        "height": 26
+      },
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node_49",
+      "type": "customDefault",
+      "position": {
+        "x": -372.42914675572706,
+        "y": 136.98860591258165
+      },
+      "data": {
+        "content": "/dev/sda1\n275GB",
+        "iconId": "hard-drive",
+        "handles": [
+          {
+            "id": "handle-1781058840099",
+            "type": "source",
+            "position": "right"
+          }
+        ]
+      },
+      "measured": {
+        "width": 150,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node_45",
+      "type": "customDefault",
+      "position": {
+        "x": -373.1150980889149,
+        "y": 239.25825222725
+      },
+      "data": {
+        "content": "/dev/sda2\n1.73TB",
+        "iconId": "hard-drive",
+        "handles": [
+          {
+            "id": "handle-1781058896795",
+            "type": "source",
+            "position": "right"
+          }
+        ]
+      },
+      "measured": {
+        "width": 150,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node_54",
+      "type": "text",
+      "position": {
+        "x": -80.64077577757585,
+        "y": 535.6297985912591
+      },
+      "data": {
+        "content": "TODO: The same is happening for \nthese disks. They're not needed \nfor controller nodes",
+        "colorScheme": "error"
+      },
+      "measured": {
+        "width": 308,
+        "height": 77
+      },
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node_55",
+      "type": "customDefault",
+      "position": {
+        "x": 1787.0073601508552,
+        "y": 443.00173260334554
+      },
+      "data": {
+        "content": "/dev/nvme01n1p3\n999GB",
+        "width": 202,
+        "height": 80,
+        "iconId": "hard-drive"
+      },
+      "measured": {
+        "width": 202,
+        "height": 80
+      },
+      "selected": false,
+      "dragging": false,
+      "resizing": false
+    },
+    {
+      "id": "node_56",
+      "type": "text",
+      "position": {
+        "x": 1209.1867613536856,
+        "y": -102.99969292567624
+      },
+      "data": {
+        "content": "Ansible playbook configures the VM.\nThen it goes into proxmox to mark \nit as a template"
+      },
+      "measured": {
+        "width": 338,
+        "height": 77
+      },
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node_57",
+      "type": "text",
+      "position": {
+        "x": 483.30177763515655,
+        "y": -100.93664367025147
+      },
+      "data": {
+        "content": "Terraform provisions the k8s VMs\nAnsible bootstraps k8s onto them."
+      },
+      "measured": {
+        "width": 324,
+        "height": 51
+      },
       "selected": false,
       "dragging": false
     }
   ],
-  "edges": []
+  "edges": [
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_28",
+      "sourceHandle": "handle-1780840798000",
+      "target": "node_1",
+      "targetHandle": "handle-1780840814117",
+      "id": "xy-edge__node_28handle-1780840798000-node_1handle-1780840814117",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_28",
+      "sourceHandle": "handle-1780840798000",
+      "target": "node_6",
+      "targetHandle": "handle-1780840805969",
+      "id": "xy-edge__node_28handle-1780840798000-node_6handle-1780840805969",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_1",
+      "sourceHandle": "handle-1780840963845",
+      "target": "node_7",
+      "targetHandle": "handle-1780840954837",
+      "id": "xy-edge__node_1handle-1780840963845-node_7handle-1780840954837",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_45",
+      "sourceHandle": "handle-1781058896795",
+      "target": "node_32",
+      "targetHandle": "handle-1781058923491",
+      "id": "xy-edge__node_45handle-1781058896795-node_32handle-1781058923491",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_49",
+      "sourceHandle": "handle-1781058840099",
+      "target": "node_31",
+      "targetHandle": "handle-1781058908141",
+      "id": "xy-edge__node_49handle-1781058840099-node_31handle-1781058908141",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_31",
+      "sourceHandle": "handle-1781059010601",
+      "target": "node_7",
+      "targetHandle": "handle-1781059004236",
+      "id": "xy-edge__node_31handle-1781059010601-node_7handle-1781059004236",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_32",
+      "sourceHandle": "handle-1781059015794",
+      "target": "node_7",
+      "targetHandle": "handle-1781059004236",
+      "id": "xy-edge__node_32handle-1781059015794-node_7handle-1781059004236",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_38",
+      "sourceHandle": "handle-1781059056066",
+      "target": "node_7",
+      "targetHandle": "handle-1781059080744",
+      "id": "xy-edge__node_38handle-1781059056066-node_7handle-1781059080744",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_35",
+      "sourceHandle": "handle-1781059060807",
+      "target": "node_7",
+      "targetHandle": "handle-1781059080744",
+      "id": "xy-edge__node_35handle-1781059060807-node_7handle-1781059080744",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_33",
+      "sourceHandle": "handle-1781059139069",
+      "target": "node_4",
+      "targetHandle": "handle-1781059130833",
+      "id": "xy-edge__node_33handle-1781059139069-node_4handle-1781059130833",
+      "selected": false,
+      "zIndex": 20,
+      "data": {
+        "active": true
+      }
+    },
+    {
+      "type": "basic",
+      "style": {
+        "stroke": "#C8D9DE",
+        "strokeWidth": 2
+      },
+      "markerEnd": {
+        "type": "arrowclosed"
+      },
+      "source": "node_4",
+      "sourceHandle": "handle-1781059131386",
+      "target": "node_7",
+      "targetHandle": "handle-1781059080744",
+      "id": "xy-edge__node_4handle-1781059131386-node_7handle-1781059080744",
+      "selected": false
+    }
+  ],
+  "isComplete": true
 }

--- a/packages/fui-icons/CLAUDE.md
+++ b/packages/fui-icons/CLAUDE.md
@@ -1,0 +1,113 @@
+# fui-icons — Custom Icon Guide
+
+## Adding a Custom Icon
+
+Custom icons are hand-crafted SVG components used when simple-icons doesn't have the icon needed (e.g. generic concepts like "router", "hard drive", "cylinder").
+
+### Step 1 — Find the SVG
+
+Preferred icon sets (in order):
+
+1. **Lucide** (`lucide.dev`) — ISC license, 24×24, stroke-based, `currentColor`
+   - Raw SVG: `https://raw.githubusercontent.com/lucide-icons/lucide/main/icons/<name>.svg`
+2. **icon-park-solid / icon-park-outline** (`iconpark.oceanengine.com`) — Apache 2.0, 48×48, fill-based
+   - Raw SVG: `https://raw.githubusercontent.com/bytedance/IconPark/master/source/solid/<name>.svg`
+3. **dashboard-icons** (`github.com/walkxcode/dashboard-icons`) — MIT, service/app logos
+
+Fetch the raw SVG via `WebFetch` on the raw GitHub URL to get exact path data.
+
+### Step 2 — Add component to `src/customIcons.tsx`
+
+Follow the existing pattern exactly. Match the source set's style:
+
+**Lucide-style** (stroke, currentColor, 24×24):
+
+```tsx
+export const MyIcon: FC<SvgIconProps> = ({ size, className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    width={size}
+    height={size}
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {/* lucide/<icon-name> — ISC license */}
+    <path d="..." />
+  </svg>
+);
+```
+
+**icon-park-style** (fill, 48×48):
+
+```tsx
+export const MyIcon: FC<SvgIconProps> = ({ size, className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    width={size}
+    height={size}
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    {/* icon-park-solid <icon-name> — Apache 2.0 */}
+    <g fill="none">
+      <path fill="#..." d="..." />
+    </g>
+  </svg>
+);
+```
+
+### Step 3 — Register in `src/customIconsMap.ts`
+
+```ts
+import { ..., MyIcon } from './customIcons';
+
+export const CUSTOM_ICONS: Record<string, FC<SvgIconProps>> = {
+  // existing entries...
+  'my-icon-key': MyIcon,
+};
+```
+
+Use kebab-case keys. The key is what consumers pass as the icon name.
+
+### Step 4 — Add to `src/registry.ts`
+
+Add an entry to `ICON_REGISTRY` so the icon is discoverable via search/picker:
+
+```ts
+{
+  id: 'my-icon-key',
+  label: 'My Icon',
+  slug: 'my-icon-key',
+  source: 'custom',
+  keywords: ['relevant', 'search', 'terms'],
+},
+```
+
+Place it in the `// custom icons` section, alphabetically by `id`.
+
+### Step 5 — Build
+
+After any source changes, always run:
+
+```bash
+pnpm build:npm
+```
+
+Run from `packages/fui-icons` or repo root (Turborepo will scope it). Required to update `dist/` before consumers pick up changes.
+
+### Existing custom icons
+
+| Key          | Component       | Source                       |
+| ------------ | --------------- | ---------------------------- |
+| `banana`     | `BananaIcon`    | icon-park-solid — Apache 2.0 |
+| `cylinder`   | `CylinderIcon`  | lucide/database — ISC        |
+| `duckdns`    | `DuckDnsIcon`   | dashboard-icons — MIT        |
+| `folder`     | `FolderIcon`    | lucide/folder — ISC          |
+| `haproxy`    | `HaproxyIcon`   | hand-crafted                 |
+| `hard-drive` | `HardDriveIcon` | lucide/hard-drive — ISC      |
+| `router`     | `RouterIcon`    | icon-park-solid — Apache 2.0 |

--- a/packages/fui-icons/src/customIcons.tsx
+++ b/packages/fui-icons/src/customIcons.tsx
@@ -106,6 +106,45 @@ export const CylinderIcon: FC<SvgIconProps> = ({ size, className }) => (
   </svg>
 );
 
+export const HardDriveIcon: FC<SvgIconProps> = ({ size, className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    width={size}
+    height={size}
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {/* lucide/hard-drive — ISC license */}
+    <path d="M10 16h.01" />
+    <path d="M2.212 11.577a2 2 0 0 0-.212.896V18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-5.527a2 2 0 0 0-.212-.896L18.55 5.11A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+    <path d="M21.946 12.013H2.054" />
+    <path d="M6 16h.01" />
+  </svg>
+);
+
+export const FolderIcon: FC<SvgIconProps> = ({ size, className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    width={size}
+    height={size}
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {/* lucide/folder — ISC license */}
+    <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+  </svg>
+);
+
 export const HaproxyIcon: FC<SvgIconProps> = ({ size, className }) => (
   <svg
     viewBox="0 0 24 24"

--- a/packages/fui-icons/src/customIconsMap.ts
+++ b/packages/fui-icons/src/customIconsMap.ts
@@ -4,7 +4,9 @@ import {
   BananaIcon,
   CylinderIcon,
   DuckDnsIcon,
+  FolderIcon,
   HaproxyIcon,
+  HardDriveIcon,
   RouterIcon,
 } from './customIcons';
 
@@ -12,6 +14,8 @@ export const CUSTOM_ICONS: Record<string, FC<SvgIconProps>> = {
   banana: BananaIcon,
   cylinder: CylinderIcon,
   duckdns: DuckDnsIcon,
+  folder: FolderIcon,
   haproxy: HaproxyIcon,
+  'hard-drive': HardDriveIcon,
   router: RouterIcon,
 };

--- a/packages/fui-icons/src/registry.ts
+++ b/packages/fui-icons/src/registry.ts
@@ -257,6 +257,20 @@ export const ICON_REGISTRY: FuiIconDefinition[] = [
     keywords: ['load-balancer', 'proxy'],
   },
   {
+    id: 'folder',
+    label: 'Folder',
+    slug: 'folder',
+    source: 'custom',
+    keywords: ['directory', 'files', 'storage', 'path', 'dir'],
+  },
+  {
+    id: 'hard-drive',
+    label: 'Hard Drive',
+    slug: 'hard-drive',
+    source: 'custom',
+    keywords: ['disk', 'storage', 'hdd', 'drive', 'volume'],
+  },
+  {
     id: 'router',
     label: 'Router',
     slug: 'router',


### PR DESCRIPTION
## Summary

- **Blog**: Color-coded tab borders in `ServiceComponentsTabs`, reordered tabs by category (ingress → virtualization → monitoring → media → pipelines)
- **Diagrams**: Expanded `diagram-02` with Ingress/CI-CD/Virtualization Platform nodes and marked complete; fleshed out `diagram-c3-virtualization` with full Proxmox layout (k8s prod/nonprod clusters, storage pools, ansible/terraform provisioning flow)
- **fui-icons**: Added `HardDriveIcon` and `FolderIcon` custom icons with registry entries; added CLAUDE.md
- **diagram-maker**: Edge active/spark control in sidebar; edge spark effect and BaseEdge hierarchy refactor; DiagramEditor/Controls/Minimap extraction
- **fui-components**: Diagram completion tracking, edge label fixes, icon support in TextNode/nodes
- **CI/infra**: Various fixes (disk prune, pnpm cache, lint pipeline improvements)

## Test plan

- [ ] Blog system architecture page renders all tabs with correct border colors
- [ ] Diagram-02 and virtualization diagram display correctly in DiagramViewer
- [ ] `hard-drive` and `folder` icons render in diagram-maker icon picker
- [ ] Edge spark effect works in diagram-maker sidebar
- [ ] CI passes (build, lint, unit tests, UI tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)