### PR TITLE
fix(blog): iOS Safari fullscreen collapse on C3 diagrams

### DIFF
--- a/apps/blog/src/components/MaskReveal/MaskReveal.tsx
+++ b/apps/blog/src/components/MaskReveal/MaskReveal.tsx
@@ -123,7 +123,11 @@ export default function MaskReveal({
         applyEdge(clipValue.value);
       },
       complete: () => {
-        el.style.clipPath = inset(0);
+        // Clear rather than leave inset(0): a lingering clip-path (even a
+        // no-op one) makes this div a containing block for fixed-position
+        // descendants, breaking iOS Safari's pseudo-fullscreen fallback in
+        // DiagramViewer for any content mounted underneath.
+        el.style.clipPath = '';
         setPhase('complete');
         onComplete?.();
       },


### PR DESCRIPTION
## Summary
- C3 diagrams on the system-architecture page are the only `DiagramViewer` instances wrapped in `MaskReveal`; C1/C2 render bare.
- `MaskReveal`'s `complete` callback set `clipPath = inset(0)` instead of clearing it, leaving the wrapper with a permanent (no-op) `clip-path` style.
- Per spec, an element with `clip-path` becomes the containing block for `position: fixed` descendants — same category as `transform`/`filter`/`perspective`.
- iOS Safari has no real Fullscreen API, so `DiagramViewer` falls back to a `position: fixed; inset: 0` pseudo-fullscreen overlay. With the MaskReveal ancestor pinning the containing block, that overlay resolved against the 500px diagram slot instead of the viewport — fullscreen appeared to just collapse the diagram area.
- Fix: clear `clipPath` (`''`) on animation complete instead of leaving `inset(0)`.

## Test plan
- [ ] On iPhone Safari, open system-architecture page, select a C3 pattern, tap fullscreen — confirm it fills the viewport like C1/C2 do.
- [ ] Confirm mask reveal animation still looks correct (no visible clipping regression) after this change.