### PR TITLE
feat: add /metrics endpoint to apps missing Prometheus scraping

### DIFF
--- a/apps/blog/src/app/api/metrics/route.ts
+++ b/apps/blog/src/app/api/metrics/route.ts
@@ -1,0 +1,3 @@
+import { metricsRoute } from '@abbottland/next-middleware';
+
+export const GET = metricsRoute;

--- a/apps/diagram-maker/src/app/api/metrics/route.ts
+++ b/apps/diagram-maker/src/app/api/metrics/route.ts
@@ -1,0 +1,3 @@
+import { metricsRoute } from '@abbottland/next-middleware';
+
+export const GET = metricsRoute;

--- a/apps/gluetun-sync/src/server.ts
+++ b/apps/gluetun-sync/src/server.ts
@@ -2,6 +2,7 @@ import express, { type Express } from 'express';
 import {
   configureBaseServerMiddleware,
   configureHealthRoute,
+  configureMetricsRoute,
 } from '@abbottland/express';
 import { config } from './config';
 import { doSync } from './controllers/sync';
@@ -12,6 +13,7 @@ export const createServer = (): Express => {
 
   configureBaseServerMiddleware(app);
   configureHealthRoute(app);
+  configureMetricsRoute(app);
 
   app
     .post('/sync', doSync)

--- a/apps/home-hud/src/app/api/metrics/route.ts
+++ b/apps/home-hud/src/app/api/metrics/route.ts
@@ -1,0 +1,3 @@
+import { metricsRoute } from '@abbottland/next-middleware';
+
+export const GET = metricsRoute;

--- a/apps/video-api/src/server.ts
+++ b/apps/video-api/src/server.ts
@@ -4,6 +4,7 @@ import {
   configureBaseServerMiddleware,
   configureErrorHandler,
   configureHealthRoute,
+  configureMetricsRoute,
   validateBody,
   validateParams,
   validateQuery,
@@ -51,6 +52,7 @@ export const createServer = (): Express => {
 
   configureBaseServerMiddleware(app);
   configureHealthRoute(app);
+  configureMetricsRoute(app);
 
   app.use(DOCS_ROUTE, swaggerUi.serve, swaggerUi.setup(openApiSpec));
 

--- a/apps/video-worker/src/server.ts
+++ b/apps/video-worker/src/server.ts
@@ -3,6 +3,7 @@ import {
   configureBaseServerMiddleware,
   configureErrorHandler,
   configureHealthRoute,
+  configureMetricsRoute,
 } from '@abbottland/express';
 import { config } from './config';
 import { getReady } from './controllers/ready';
@@ -12,6 +13,7 @@ export const createServer = (): Express => {
 
   configureBaseServerMiddleware(app);
   configureHealthRoute(app);
+  configureMetricsRoute(app);
 
   app.get('/readyz', getReady);
 

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -5,5 +5,6 @@ export { validateParams } from './middleware/validate-params/validate-params';
 export { validateQuery } from './middleware/validate-query/validate-query';
 
 export { configureHealthRoute } from './routes/health-route/health-route';
+export { configureMetricsRoute } from './routes/metrics-route/metrics-route';
 
 export type { ValidationError } from './lib/format-zod-error';

--- a/packages/express/src/routes/metrics-route/metrics-route.integration.test.ts
+++ b/packages/express/src/routes/metrics-route/metrics-route.integration.test.ts
@@ -1,0 +1,38 @@
+import { Express } from 'express';
+import request from 'supertest';
+import { configureMetricsRoute } from './metrics-route';
+import { createTestApp } from '../../test-setup/integration-test-setup';
+
+describe('Metrics Route Integration Tests', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = createTestApp();
+    configureMetricsRoute(app);
+  });
+
+  describe('GET /metrics', () => {
+    it('should return 200 status with Prometheus text format', async () => {
+      const response = await request(app).get('/metrics').expect(200);
+
+      expect(response.text).toContain('app_up 1');
+      expect(response.text).toContain('process_uptime_seconds');
+    });
+
+    it('should return the Prometheus exposition content type', async () => {
+      const response = await request(app).get('/metrics').expect(200);
+
+      expect(response.headers['content-type']).toMatch(/text\/plain/);
+    });
+
+    it('should not interfere with other routes', async () => {
+      app.get('/other', (_, res) => res.json({ message: 'other' }));
+
+      await request(app).get('/metrics').expect(200);
+
+      const otherResponse = await request(app).get('/other').expect(200);
+
+      expect(otherResponse.body).toEqual({ message: 'other' });
+    });
+  });
+});

--- a/packages/express/src/routes/metrics-route/metrics-route.ts
+++ b/packages/express/src/routes/metrics-route/metrics-route.ts
@@ -1,0 +1,22 @@
+import { Express } from 'express';
+
+const startTime = Date.now();
+
+export const configureMetricsRoute = (app: Express) => {
+  app.get('/metrics', (_, res) => {
+    const uptimeSeconds = (Date.now() - startTime) / 1000;
+
+    const output =
+      [
+        '# HELP app_up Whether the service process is up and responding',
+        '# TYPE app_up gauge',
+        'app_up 1',
+        '# HELP process_uptime_seconds Seconds since the process started',
+        '# TYPE process_uptime_seconds gauge',
+        `process_uptime_seconds ${uptimeSeconds}`,
+      ].join('\n') + '\n';
+
+    res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+    res.status(200).send(output);
+  });
+};

--- a/packages/express/src/routes/metrics-route/metrics-route.unit.test.ts
+++ b/packages/express/src/routes/metrics-route/metrics-route.unit.test.ts
@@ -1,0 +1,14 @@
+import { Express } from 'express';
+import { configureMetricsRoute } from './metrics-route';
+
+describe('configureMetricsRoute (unit test)', () => {
+  it('should configure the metrics endpoint on the provided Express app', () => {
+    const mockApp = {
+      get: jest.fn(),
+    } as unknown as Express;
+
+    configureMetricsRoute(mockApp);
+
+    expect(mockApp.get).toHaveBeenCalledWith('/metrics', expect.any(Function));
+  });
+});

--- a/packages/next-middleware/src/index.ts
+++ b/packages/next-middleware/src/index.ts
@@ -1,1 +1,2 @@
 export { healthzRoute } from './routes/healthz-route/healthz-route';
+export { metricsRoute } from './routes/metrics-route/metrics-route';

--- a/packages/next-middleware/src/routes/metrics-route/metrics-route.ts
+++ b/packages/next-middleware/src/routes/metrics-route/metrics-route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+const startTime = Date.now();
+
+export const metricsRoute = async () => {
+  const uptimeSeconds = (Date.now() - startTime) / 1000;
+
+  const output =
+    [
+      '# HELP app_up Whether the service process is up and responding',
+      '# TYPE app_up gauge',
+      'app_up 1',
+      '# HELP process_uptime_seconds Seconds since the process started',
+      '# TYPE process_uptime_seconds gauge',
+      `process_uptime_seconds ${uptimeSeconds}`,
+    ].join('\n') + '\n';
+
+  return new NextResponse(output, {
+    status: 200,
+    headers: { 'Content-Type': 'text/plain; version=0.0.4; charset=utf-8' },
+  });
+};

--- a/packages/next-middleware/src/routes/metrics-route/metrics-route.unit.test.ts
+++ b/packages/next-middleware/src/routes/metrics-route/metrics-route.unit.test.ts
@@ -1,0 +1,14 @@
+import { metricsRoute } from './metrics-route';
+
+describe('metricsRoute (unit test)', () => {
+  it('should return a 200 response with Prometheus text format', async () => {
+    const response = await metricsRoute();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toMatch(/text\/plain/);
+
+    const body = await response.text();
+    expect(body).toContain('app_up 1');
+    expect(body).toContain('process_uptime_seconds');
+  });
+});


### PR DESCRIPTION
## Summary
- Only `harbor-cleanup` exposed `/metrics`. The other 6 deployed apps had no way for Prometheus to scrape liveness (the `up` metric), which is needed for an "are all my home-web-apps alive" Grafana dashboard.
- Adds `configureMetricsRoute` (`packages/express`, mirrors `configureHealthRoute`) and `metricsRoute` (`packages/next-middleware`, mirrors `healthzRoute`) — a minimal, dependency-free Prometheus text endpoint (`app_up`, `process_uptime_seconds`), matching harbor-cleanup's existing hand-rolled style rather than introducing a metrics library.
- Wired into `video-api`, `video-worker`, `gluetun-sync` (Express) and `blog`, `diagram-maker`, `home-hud` (Next.js API route).
- `pi-led-api` intentionally excluded — it isn't deployed anywhere in the cluster.

Companion `home-kubernetes` changes (Services with named `http` ports, `ServiceMonitor`s, and the Grafana dashboard) will land separately once this is merged and images are built.

## Test plan
- [x] `pnpm lint` clean across all 8 touched packages/apps
- [x] `pnpm --filter @abbottland/express --filter @abbottland/next-middleware test:unit` — 11 passed
- [x] `pnpm --filter @abbottland/express test:int` — 27 passed (new metrics-route.integration.test.ts included)
- [x] `tsc` build clean for video-api, video-worker, gluetun-sync
- [ ] CI: full Next.js builds for blog/diagram-maker/home-hud (couldn't verify locally — this host's Node 20 can't build `fui-components`/Storybook, a pre-existing local-env gap unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VoX2Yn8s6VXUcJBUn7582