### PR TITLE
fix(video-worker): key screenshot folders by file content hash

### DIFF
--- a/apps/video-api/src/lib/resolve-and-hash-path.ts
+++ b/apps/video-api/src/lib/resolve-and-hash-path.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
+import { hashFile } from '@abbottland/video-db';
 import { config } from '../config';
-import { hashFile } from './file-hash';
 import { resolveWithinRoot } from './safe-path';
 
 export type ResolveAndHashResult =

--- a/apps/video-api/tests/unit/file-renames.unit.test.ts
+++ b/apps/video-api/tests/unit/file-renames.unit.test.ts
@@ -2,21 +2,21 @@ import fs from 'fs';
 import os from 'os';
 import supertest from 'supertest';
 import * as videoDb from '@abbottland/video-db';
+import { hashFile } from '@abbottland/video-db';
 import { createServer } from '../../src/server';
 import { initConfig } from '../../src/config';
-import { hashFile } from '../../src/lib/file-hash';
 
 jest.mock('fs');
-jest.mock('../../src/lib/file-hash');
 // Partial mock: keep real value exports (e.g. fileRenameSelectSchema, which
 // openapi.ts needs to build the doc at module-load time) and only mock the
-// query functions under test here.
+// query functions and hashFile under test here.
 jest.mock('@abbottland/video-db', () => ({
   ...jest.requireActual('@abbottland/video-db'),
   upsertFileRename: jest.fn(),
   getFileRenameById: jest.fn(),
   updateFileRenameStatus: jest.fn(),
   listFileRenames: jest.fn(),
+  hashFile: jest.fn(),
 }));
 
 const sampleFileRename = {

--- a/apps/video-api/tests/unit/hash.unit.test.ts
+++ b/apps/video-api/tests/unit/hash.unit.test.ts
@@ -1,12 +1,18 @@
 import fs from 'fs';
 import os from 'os';
 import supertest from 'supertest';
+import { hashFile } from '@abbottland/video-db';
 import { createServer } from '../../src/server';
 import { initConfig } from '../../src/config';
-import { hashFile } from '../../src/lib/file-hash';
 
 jest.mock('fs');
-jest.mock('../../src/lib/file-hash');
+// Partial mock: keep real value exports (e.g. select schemas, which
+// openapi.ts needs to build the doc at module-load time) and only mock
+// hashFile under test here.
+jest.mock('@abbottland/video-db', () => ({
+  ...jest.requireActual('@abbottland/video-db'),
+  hashFile: jest.fn(),
+}));
 
 describe('GET /hash', () => {
   let consoleErrorSpy: jest.SpyInstance;

--- a/apps/video-api/tests/unit/title-cards.unit.test.ts
+++ b/apps/video-api/tests/unit/title-cards.unit.test.ts
@@ -2,20 +2,20 @@ import fs from 'fs';
 import os from 'os';
 import supertest from 'supertest';
 import * as videoDb from '@abbottland/video-db';
+import { hashFile } from '@abbottland/video-db';
 import { createServer } from '../../src/server';
 import { initConfig } from '../../src/config';
-import { hashFile } from '../../src/lib/file-hash';
 
 jest.mock('fs');
-jest.mock('../../src/lib/file-hash');
 // Partial mock: keep real value exports (e.g. titleCardSelectSchema, which
 // openapi.ts needs to build the doc at module-load time) and only mock the
-// query functions under test here.
+// query functions and hashFile under test here.
 jest.mock('@abbottland/video-db', () => ({
   ...jest.requireActual('@abbottland/video-db'),
   upsertTitleCard: jest.fn(),
   getTitleCardById: jest.fn(),
   listTitleCards: jest.fn(),
+  hashFile: jest.fn(),
 }));
 
 const sampleTitleCard = {

--- a/apps/video-worker/src/worker/operations/screenshots.ts
+++ b/apps/video-worker/src/worker/operations/screenshots.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'child_process';
 import fs from 'fs';
 import { promisify } from 'util';
-import type { VideoJob } from '@abbottland/video-db';
+import { hashFile, type VideoJob } from '@abbottland/video-db';
 import { config } from '../../config';
 import { resolveWithinRoot } from '../../lib/safe-path';
 import { JobProcessingError } from '../job-processing-error';
@@ -25,8 +25,12 @@ const isScreenshotParameters = (
 
 /**
  * Extracts one JPEG per timestamp in `job.parameters.timestamps` and writes
- * them to `screenshots/<jobId>/<timestamp>.jpg` under MEDIA_ROOT. Returns
- * the generated paths, relative to MEDIA_ROOT, in timestamp order.
+ * them to `screenshots/<inputFileHash>/<timestamp>.jpg` under MEDIA_ROOT.
+ * Keying by the input file's content hash (rather than the job id) means
+ * re-running screenshots for the same file — even via a different job, or
+ * after the file is renamed — lands in the same folder, and a timestamp
+ * already present there is left alone rather than re-extracted. Returns the
+ * generated paths, relative to MEDIA_ROOT, in timestamp order.
  */
 export const runScreenshotsOperation = async (
   job: VideoJob,
@@ -49,7 +53,8 @@ export const runScreenshotsOperation = async (
     throw new JobProcessingError(`input file not found: ${job.inputPath}`);
   }
 
-  const outputRelDir = `/screenshots/${job.id}`;
+  const inputHash = await hashFile(inputAbsPath);
+  const outputRelDir = `/screenshots/${inputHash}`;
   const outputAbsDir = resolveWithinRoot(config.mediaRoot, outputRelDir);
 
   if (!outputAbsDir) {
@@ -70,16 +75,18 @@ export const runScreenshotsOperation = async (
       throw new JobProcessingError('generated output path escapes MEDIA_ROOT');
     }
 
-    await execFileAsync(config.ffmpegPath, [
-      '-ss',
-      String(timestamp),
-      '-i',
-      inputAbsPath,
-      '-frames:v',
-      '1',
-      '-y',
-      outputAbsPath,
-    ]);
+    if (!fs.existsSync(outputAbsPath)) {
+      await execFileAsync(config.ffmpegPath, [
+        '-ss',
+        String(timestamp),
+        '-i',
+        inputAbsPath,
+        '-frames:v',
+        '1',
+        '-y',
+        outputAbsPath,
+      ]);
+    }
 
     outputPaths.push(outputRelPath);
   }

--- a/apps/video-worker/tests/integration/poll-loop.integration.test.ts
+++ b/apps/video-worker/tests/integration/poll-loop.integration.test.ts
@@ -1,11 +1,14 @@
+import path from 'path';
 import { execFile } from 'child_process';
 import {
   claimNextVideoJob,
   createVideoJob,
   getVideoJobById,
+  hashFile,
 } from '@abbottland/video-db';
 import { db } from '../../src/db';
 import { processJob } from '../../src/worker/job-processor';
+import { MEDIA_ROOT } from '../jest.integration.setup';
 
 // No ffmpeg binary is guaranteed in CI/dev containers. Mocking the
 // subprocess call keeps this test focused on what it can actually verify:
@@ -44,10 +47,13 @@ describe('worker job processing', () => {
     await processJob(claimed!);
 
     const updated = await getVideoJobById(db, created.id);
+    const inputHash = await hashFile(
+      path.join(MEDIA_ROOT, 'videos', 'example.mp4'),
+    );
     expect(updated?.status).toBe('completed');
     expect(updated?.outputPaths).toEqual([
-      `/screenshots/${created.id}/30.jpg`,
-      `/screenshots/${created.id}/60.jpg`,
+      `/screenshots/${inputHash}/30.jpg`,
+      `/screenshots/${inputHash}/60.jpg`,
     ]);
     expect(updated?.workerId).toBe('test-worker');
     expect(updated?.attempts).toBe(1);

--- a/apps/video-worker/tests/unit/screenshots.unit.test.ts
+++ b/apps/video-worker/tests/unit/screenshots.unit.test.ts
@@ -4,6 +4,8 @@ import { runScreenshotsOperation } from '../../src/worker/operations/screenshots
 import { JobProcessingError } from '../../src/worker/job-processing-error';
 import type { VideoJob } from '@abbottland/video-db';
 
+const FAKE_HASH = 'fakehash1234567890';
+
 jest.mock('fs');
 jest.mock('child_process', () => ({
   execFile: jest.fn(
@@ -18,6 +20,9 @@ jest.mock('child_process', () => ({
 }));
 jest.mock('../../src/config', () => ({
   config: { mediaRoot: '/media', ffmpegPath: 'ffmpeg' },
+}));
+jest.mock('@abbottland/video-db', () => ({
+  hashFile: jest.fn().mockResolvedValue('fakehash1234567890'),
 }));
 
 const buildJob = (overrides: Partial<VideoJob> = {}): VideoJob =>
@@ -40,7 +45,11 @@ const buildJob = (overrides: Partial<VideoJob> = {}): VideoJob =>
 
 describe('runScreenshotsOperation', () => {
   beforeEach(() => {
-    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    // Input file exists; output screenshots don't yet, so ffmpeg runs
+    // unless a test overrides this to simulate an already-generated file.
+    (fs.existsSync as jest.Mock).mockImplementation(
+      (path: string) => path === '/media/videos/example.mp4',
+    );
     (fs.mkdirSync as jest.Mock).mockReturnValue(undefined);
   });
 
@@ -74,14 +83,37 @@ describe('runScreenshotsOperation', () => {
     const outputPaths = await runScreenshotsOperation(job);
 
     expect(outputPaths).toEqual([
-      `/screenshots/${job.id}/30.jpg`,
-      `/screenshots/${job.id}/120.jpg`,
+      `/screenshots/${FAKE_HASH}/30.jpg`,
+      `/screenshots/${FAKE_HASH}/120.jpg`,
     ]);
     expect(execFile).toHaveBeenCalledTimes(2);
     expect(execFile).toHaveBeenNthCalledWith(
       1,
       'ffmpeg',
       expect.arrayContaining(['-ss', '30', '-i', '/media/videos/example.mp4']),
+      expect.any(Function),
+    );
+  });
+
+  it('skips ffmpeg for timestamps whose screenshot already exists', async () => {
+    const job = buildJob();
+
+    (fs.existsSync as jest.Mock).mockImplementation(
+      (path: string) =>
+        path === '/media/videos/example.mp4' ||
+        path === `/media/screenshots/${FAKE_HASH}/30.jpg`,
+    );
+
+    const outputPaths = await runScreenshotsOperation(job);
+
+    expect(outputPaths).toEqual([
+      `/screenshots/${FAKE_HASH}/30.jpg`,
+      `/screenshots/${FAKE_HASH}/120.jpg`,
+    ]);
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(execFile).toHaveBeenCalledWith(
+      'ffmpeg',
+      expect.arrayContaining(['-ss', '120', '-i', '/media/videos/example.mp4']),
       expect.any(Function),
     );
   });

--- a/packages/video-db/src/file-hash.ts
+++ b/packages/video-db/src/file-hash.ts
@@ -3,9 +3,10 @@ import fs from 'fs';
 
 /**
  * Streams the full file at `absPath` through SHA-256. Used as the
- * rename-proof identity for a video file: source filenames in this library
- * routinely don't match episode titles, so paths alone can't be trusted to
- * stay pointed at the same content.
+ * rename-proof identity for a video file: source filenames routinely don't
+ * match episode titles or stay put, so paths alone can't be trusted to
+ * stay pointed at the same content. Shared between video-api and
+ * video-worker so both hash files identically.
  */
 export const hashFile = (absPath: string): Promise<string> =>
   new Promise((resolve, reject) => {

--- a/packages/video-db/src/index.ts
+++ b/packages/video-db/src/index.ts
@@ -1,6 +1,8 @@
 export { createDb, closeDb, pingDb } from './client';
 export type { Database, PostgresConnectionOptions } from './client';
 
+export { hashFile } from './file-hash';
+
 export {
   videoJobs,
   videoJobStatusEnum,


### PR DESCRIPTION
## Summary
- Screenshot output folders were keyed by `job.id`, so re-running screenshots for the same input file (a new job, or after the file was renamed) landed in a fresh folder instead of reusing the existing one. Now keyed by `screenshots/<sha256-of-file>`.
- Moved `hashFile` (SHA-256 stream) out of `video-api` and into `video-db`, since it's now shared between `video-api` and `video-worker` — both apps hash a file identically.
- `runScreenshotsOperation` now skips ffmpeg for any timestamp whose screenshot already exists at its intended path, instead of always regenerating it.

## Test plan
- [x] `pnpm --filter @abbottland/video-api test:unit` — 57 passed
- [x] `pnpm --filter @abbottland/video-worker test:unit` — 30 passed (incl. new skip-existing-screenshot case)
- [x] `pnpm --filter @abbottland/video-db test:unit` — 9 passed
- [x] `pnpm --filter @abbottland/video-api --filter @abbottland/video-worker --filter @abbottland/video-db lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6MtcZyAmkYmiQdSzS1ELh