### PR TITLE
feat(video-api): add GET /run-time, record runtime on title cards

### DIFF
--- a/apps/video-api/Dockerfile
+++ b/apps/video-api/Dockerfile
@@ -1,0 +1,27 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
+
+FROM node:22-alpine AS runner
+
+# ffmpeg (ffprobe) is the only thing video-api needs beyond the shared
+# Node.js runner image, for GET /run-time and POST /title-cards. Most other
+# apps build off docker/pnpm-turbo.Dockerfile's runner stage directly, but
+# that stage is shared, so ffmpeg is installed here instead of bloating
+# every other app's image (see also video-worker's Dockerfile).
+RUN apk update && apk add --no-cache ffmpeg
+
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser  --system --uid 1001 nodejs
+
+WORKDIR /app
+COPY --from=builder --chown=nodejs:nodejs /app .
+WORKDIR /app/apps/video-api
+
+USER nodejs
+
+ARG PORT=4002
+ENV PORT=${PORT}
+ENV NODE_ENV=production
+EXPOSE ${PORT}
+
+CMD ["node", "dist/index.js"]

--- a/apps/video-api/abctl.base.yml
+++ b/apps/video-api/abctl.base.yml
@@ -1,0 +1,6 @@
+registryWithNamespace: harbor.local.abbottland.io/library
+buildPreset: pnpm-turbo-docker-build
+build:
+  repository: video-api-base
+  target: builder
+  push: 'true'

--- a/apps/video-api/abctl.yml
+++ b/apps/video-api/abctl.yml
@@ -1,5 +1,7 @@
-buildPreset: pnpm-turbo-docker-build
+baseConfig: ./abctl.base.yml
 build:
+  dockerfile: Dockerfile
+  context: .
   buildCache: harbor.local.abbottland.io/build-cache
 secrets:
   generateEnv: true

--- a/apps/video-api/package.json
+++ b/apps/video-api/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "docker:build:base": "abctl docker build -c abctl.base.yml",
     "docker:build": "abctl docker build",
+    "docker:publish:base": "abctl docker publish -c abctl.base.yml",
     "docker:publish": "abctl docker publish",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",

--- a/apps/video-api/src/config.ts
+++ b/apps/video-api/src/config.ts
@@ -35,6 +35,10 @@ export class ApplicationConfig {
   @EnvironmentVariable()
   mediaRoot: string = '';
 
+  /** Path/binary name used to invoke ffprobe (for GET /run-time and POST /title-cards). Must be on PATH in the container. */
+  @EnvironmentVariable()
+  ffprobePath: string = 'ffprobe';
+
   @ConfigSection({ sectionPrefix: 'POSTGRES' })
   postgres = new PostgresConfig();
 }

--- a/apps/video-api/src/controllers/run-time.ts
+++ b/apps/video-api/src/controllers/run-time.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+import { resolveFilePath } from '../lib/resolve-file-path';
+import { getRuntimeSeconds } from '../lib/get-runtime';
+import type { RunTimeQuery } from '../schemas/run-time';
+
+export const getRunTime = async (req: Request, res: Response) => {
+  // req.query is already validated/typed by the validateQuery(runTimeQuerySchema) middleware.
+  const { filePath } = req.query as RunTimeQuery;
+
+  try {
+    const resolved = resolveFilePath(filePath);
+    if (resolved.ok === false) {
+      return res.status(resolved.status).json({ message: resolved.message });
+    }
+
+    const runTimeSeconds = await getRuntimeSeconds(resolved.absPath);
+
+    res.status(200).json({ filePath, runTimeSeconds });
+  } catch (err) {
+    console.error('GET /run-time failed:', err);
+    res.status(500).json({ message: 'internal server error' });
+  }
+};

--- a/apps/video-api/src/controllers/title-cards.ts
+++ b/apps/video-api/src/controllers/title-cards.ts
@@ -1,11 +1,14 @@
 import { Request, Response } from 'express';
 import {
   getTitleCardById,
+  hashFile,
   listTitleCards,
   upsertTitleCard,
 } from '@abbottland/video-db';
 import { db } from '../db';
 import { resolveAndHashPath } from '../lib/resolve-and-hash-path';
+import { resolveFilePath } from '../lib/resolve-file-path';
+import { getRuntimeSeconds } from '../lib/get-runtime';
 import type {
   CreateTitleCardBody,
   ListTitleCardsQuery,
@@ -17,15 +20,21 @@ export const postTitleCard = async (req: Request, res: Response) => {
     req.body as CreateTitleCardBody;
 
   try {
-    const result = await resolveAndHashPath(filePath);
-    if (result.ok === false) {
-      return res.status(result.status).json({ message: result.message });
+    const resolved = resolveFilePath(filePath);
+    if (resolved.ok === false) {
+      return res.status(resolved.status).json({ message: resolved.message });
     }
 
+    const [fileHash, runTimeSeconds] = await Promise.all([
+      hashFile(resolved.absPath),
+      getRuntimeSeconds(resolved.absPath),
+    ]);
+
     const titleCard = await upsertTitleCard(db, {
-      fileHash: result.hash,
+      fileHash,
       filePath,
       timestampSeconds,
+      runTimeSeconds,
       title,
       screenshotPath,
     });

--- a/apps/video-api/src/lib/get-runtime.ts
+++ b/apps/video-api/src/lib/get-runtime.ts
@@ -1,0 +1,24 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { config } from '../config';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Runs ffprobe against `absPath` and returns the file's duration in whole
+ * seconds (rounded, since callers only need enough precision to eyeball how
+ * many title cards a file should have).
+ */
+export const getRuntimeSeconds = async (absPath: string): Promise<number> => {
+  const { stdout } = await execFileAsync(config.ffprobePath, [
+    '-v',
+    'error',
+    '-show_entries',
+    'format=duration',
+    '-of',
+    'default=noprint_wrappers=1:nokey=1',
+    absPath,
+  ]);
+
+  return Math.round(Number(stdout.trim()));
+};

--- a/apps/video-api/src/lib/resolve-and-hash-path.ts
+++ b/apps/video-api/src/lib/resolve-and-hash-path.ts
@@ -1,7 +1,5 @@
-import fs from 'fs';
 import { hashFile } from '@abbottland/video-db';
-import { config } from '../config';
-import { resolveWithinRoot } from './safe-path';
+import { resolveFilePath } from './resolve-file-path';
 
 export type ResolveAndHashResult =
   | { ok: true; hash: string }
@@ -16,20 +14,12 @@ export type ResolveAndHashResult =
 export const resolveAndHashPath = async (
   filePath: string,
 ): Promise<ResolveAndHashResult> => {
-  const absPath = resolveWithinRoot(config.mediaRoot, filePath);
+  const resolved = resolveFilePath(filePath);
 
-  if (!absPath) {
-    return {
-      ok: false,
-      status: 400,
-      message: 'filePath is outside the configured media root',
-    };
+  if (resolved.ok === false) {
+    return resolved;
   }
 
-  if (!fs.existsSync(absPath)) {
-    return { ok: false, status: 404, message: 'file not found' };
-  }
-
-  const hash = await hashFile(absPath);
+  const hash = await hashFile(resolved.absPath);
   return { ok: true, hash };
 };

--- a/apps/video-api/src/lib/resolve-file-path.ts
+++ b/apps/video-api/src/lib/resolve-file-path.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import { config } from '../config';
+import { resolveWithinRoot } from './safe-path';
+
+export type ResolveFilePathResult =
+  | { ok: true; absPath: string }
+  | { ok: false; status: 400 | 404; message: string };
+
+/**
+ * Resolves `filePath` within MEDIA_ROOT and confirms it exists. Shared
+ * first step for anything that needs to read the file itself (hashing,
+ * probing runtime) — callers translate the failure case into an HTTP
+ * response themselves, so this stays reusable across controllers without
+ * any Express coupling.
+ */
+export const resolveFilePath = (filePath: string): ResolveFilePathResult => {
+  const absPath = resolveWithinRoot(config.mediaRoot, filePath);
+
+  if (!absPath) {
+    return {
+      ok: false,
+      status: 400,
+      message: 'filePath is outside the configured media root',
+    };
+  }
+
+  if (!fs.existsSync(absPath)) {
+    return { ok: false, status: 404, message: 'file not found' };
+  }
+
+  return { ok: true, absPath };
+};

--- a/apps/video-api/src/openapi.ts
+++ b/apps/video-api/src/openapi.ts
@@ -12,6 +12,7 @@ import {
 } from './schemas/jobs';
 import { browseQuerySchema } from './schemas/browse';
 import { hashQuerySchema } from './schemas/hash';
+import { runTimeQuerySchema } from './schemas/run-time';
 import {
   createTitleCardSchema,
   listTitleCardsQuerySchema,
@@ -206,6 +207,31 @@ export const openApiSpec = createDocument({
         },
       },
     },
+    '/run-time': {
+      get: {
+        summary: 'Get the runtime (duration) of a video file',
+        description:
+          'Resolves filePath within MEDIA_ROOT and probes it with ffprobe. Runtime is also recorded automatically on POST /title-cards, so this route is mainly useful for checking a file up front.',
+        requestParams: { query: runTimeQuerySchema },
+        responses: {
+          '200': {
+            description: 'The runtime in seconds',
+            content: {
+              'application/json': {
+                schema: z.object({
+                  filePath: z.string(),
+                  runTimeSeconds: z.number(),
+                }),
+              },
+            },
+          },
+          '400': {
+            description: 'filePath escapes MEDIA_ROOT',
+          },
+          '404': { description: 'filePath does not exist' },
+        },
+      },
+    },
     '/title-cards': {
       get: {
         summary: 'List recorded title cards, optionally filtered by file',
@@ -232,7 +258,7 @@ export const openApiSpec = createDocument({
       post: {
         summary: 'Record the timestamp a title card was found at',
         description:
-          'The video file at filePath is hashed (SHA-256) server-side; the hash, not filePath, is the identity used to key this record, so it stays valid if the file is later renamed. Re-submitting the same filePath/timestampSeconds pair updates the existing record instead of erroring.',
+          'The video file at filePath is hashed (SHA-256) and probed for runtime (ffprobe) server-side; the hash, not filePath, is the identity used to key this record, so it stays valid if the file is later renamed. runTimeSeconds reflects the whole file and is the same across every card recorded for it. Re-submitting the same filePath/timestampSeconds pair updates the existing record instead of erroring.',
         requestBody: {
           content: { 'application/json': { schema: createTitleCardSchema } },
         },

--- a/apps/video-api/src/schemas/run-time.ts
+++ b/apps/video-api/src/schemas/run-time.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const runTimeQuerySchema = z.object({
+  filePath: z.string().min(1, 'filePath is required').meta({
+    description: 'Path to the video file, relative to MEDIA_ROOT',
+    example: '/tv_shows/Show A/S01E01.mp4',
+  }),
+});
+
+export type RunTimeQuery = z.infer<typeof runTimeQuerySchema>;

--- a/apps/video-api/src/server.ts
+++ b/apps/video-api/src/server.ts
@@ -20,6 +20,7 @@ import {
 import { getHash } from './controllers/hash';
 import { getJob, listJobs, postJob } from './controllers/jobs';
 import { getReady } from './controllers/ready';
+import { getRunTime } from './controllers/run-time';
 import {
   getTitleCard,
   listTitleCardsHandler,
@@ -33,6 +34,7 @@ import {
 } from './schemas/jobs';
 import { browseQuerySchema } from './schemas/browse';
 import { hashQuerySchema } from './schemas/hash';
+import { runTimeQuerySchema } from './schemas/run-time';
 import {
   createTitleCardSchema,
   listTitleCardsQuerySchema,
@@ -63,6 +65,7 @@ export const createServer = (): Express => {
     .get('/jobs/:id', validateParams(jobIdParamsSchema), getJob)
     .get('/browse', validateQuery(browseQuerySchema), browseDirectory)
     .get('/hash', validateQuery(hashQuerySchema), getHash)
+    .get('/run-time', validateQuery(runTimeQuerySchema), getRunTime)
     .post('/title-cards', validateBody(createTitleCardSchema), postTitleCard)
     .get(
       '/title-cards',

--- a/apps/video-api/tests/integration/run-time.integration.test.ts
+++ b/apps/video-api/tests/integration/run-time.integration.test.ts
@@ -1,0 +1,45 @@
+import { execFile } from 'child_process';
+import { getRequest } from '../jest.integration.setup';
+
+// child_process is mocked globally in jest.integration.setup.ts (see the
+// comment there); override its default stdout with a fixed runtime so
+// notes.txt (not a real video) can still stand in for the ffprobe call.
+(execFile as unknown as jest.Mock).mockImplementation(
+  (
+    _file: string,
+    _args: string[],
+    callback: (err: Error | null, result?: unknown) => void,
+  ) => callback(null, { stdout: '659.600000\n', stderr: '' }),
+);
+
+describe('GET /run-time', () => {
+  const filePath = '/tv_shows/notes.txt';
+
+  it('returns the probed runtime, rounded to whole seconds', async () => {
+    await getRequest()
+      .get('/run-time')
+      .query({ filePath })
+      .expect(200)
+      .then((res) => {
+        expect(res.body).toEqual({ filePath, runTimeSeconds: 660 });
+      });
+  });
+
+  it('rejects a filePath that escapes MEDIA_ROOT', async () => {
+    await getRequest()
+      .get('/run-time')
+      .query({ filePath: '../../etc/passwd' })
+      .expect(400);
+  });
+
+  it('returns 404 for a nonexistent file', async () => {
+    await getRequest()
+      .get('/run-time')
+      .query({ filePath: '/tv_shows/does-not-exist.mp4' })
+      .expect(404);
+  });
+
+  it('rejects a missing filePath', async () => {
+    await getRequest().get('/run-time').expect(400);
+  });
+});

--- a/apps/video-api/tests/integration/title-cards.integration.test.ts
+++ b/apps/video-api/tests/integration/title-cards.integration.test.ts
@@ -1,7 +1,20 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
+import { execFile } from 'child_process';
 import { getRequest, MEDIA_ROOT } from '../jest.integration.setup';
+
+// child_process is mocked globally in jest.integration.setup.ts (see the
+// comment there); override its default stdout with a fixed runtime so
+// notes.txt (not a real video) can still stand in for POST /title-cards'
+// runtime probe.
+(execFile as unknown as jest.Mock).mockImplementation(
+  (
+    _file: string,
+    _args: string[],
+    callback: (err: Error | null, result?: unknown) => void,
+  ) => callback(null, { stdout: '660.000000\n', stderr: '' }),
+);
 
 describe('title-cards', () => {
   const filePath = '/tv_shows/notes.txt';
@@ -20,8 +33,24 @@ describe('title-cards', () => {
           expect(res.body.fileHash).toBe(expectedHash);
           expect(res.body.filePath).toBe(filePath);
           expect(res.body.timestampSeconds).toBe(128);
+          expect(res.body.runTimeSeconds).toBe(660);
           expect(res.body.title).toBe('Pups Save a Toof');
         });
+    });
+
+    it('carries the same runTimeSeconds across multiple cards for the same file', async () => {
+      const first = await getRequest()
+        .post('/title-cards')
+        .send({ filePath, timestampSeconds: 250 })
+        .expect(201);
+
+      const second = await getRequest()
+        .post('/title-cards')
+        .send({ filePath, timestampSeconds: 600 })
+        .expect(201);
+
+      expect(first.body.runTimeSeconds).toBe(660);
+      expect(second.body.runTimeSeconds).toBe(660);
     });
 
     it('updates the existing record instead of erroring on a repeat submission', async () => {

--- a/apps/video-api/tests/jest.integration.setup.ts
+++ b/apps/video-api/tests/jest.integration.setup.ts
@@ -7,6 +7,25 @@ import { createServer } from '../src/server';
 import { initConfig, validateConfig } from '../src/config';
 import { db, initDb } from '../src/db';
 
+// No ffprobe binary is guaranteed in CI/dev containers. This mock is
+// registered here (not per-test-file) because createServer's module graph
+// — via controllers/run-time.ts and controllers/title-cards.ts — binds
+// child_process.execFile at import time, and jest.mock() calls are hoisted
+// above ALL imports in a file (including the '../src/server' import above),
+// so this is what actually intercepts it. A per-test-file jest.mock would
+// be too late: by then server.ts's module graph is already cached with the
+// real execFile. Individual test files can override the default stdout
+// with execFile.mockImplementation(...).
+jest.mock('child_process', () => ({
+  execFile: jest.fn(
+    (
+      _file: string,
+      _args: string[],
+      callback: (err: Error | null, result?: unknown) => void,
+    ) => callback(null, { stdout: '0\n', stderr: '' }),
+  ),
+}));
+
 export const MEDIA_ROOT = fs.mkdtempSync(
   path.join(os.tmpdir(), 'video-api-media-'),
 );

--- a/apps/video-api/tests/unit/run-time.unit.test.ts
+++ b/apps/video-api/tests/unit/run-time.unit.test.ts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import os from 'os';
+import { execFile } from 'child_process';
+import supertest from 'supertest';
+import { createServer } from '../../src/server';
+import { initConfig } from '../../src/config';
+
+jest.mock('fs');
+jest.mock('child_process', () => ({
+  execFile: jest.fn(),
+}));
+
+describe('GET /run-time', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    process.env.MEDIA_ROOT = os.tmpdir();
+    await initConfig();
+  });
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.resetAllMocks();
+  });
+
+  it('rejects a filePath that escapes MEDIA_ROOT', async () => {
+    const res = await supertest(createServer())
+      .get('/run-time')
+      .query({ filePath: '../../etc/passwd' })
+      .expect(400);
+
+    expect(res.body.message).toContain('outside');
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the file does not exist', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+    const res = await supertest(createServer())
+      .get('/run-time')
+      .query({ filePath: '/videos/missing.mp4' })
+      .expect(404);
+
+    expect(res.body.message).toBe('file not found');
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it('returns the probed runtime, rounded to whole seconds', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (execFile as unknown as jest.Mock).mockImplementation(
+      (_file, _args, callback) => callback(null, { stdout: '659.876000\n' }),
+    );
+
+    const res = await supertest(createServer())
+      .get('/run-time')
+      .query({ filePath: '/videos/example.mp4' })
+      .expect(200);
+
+    expect(execFile).toHaveBeenCalledWith(
+      'ffprobe',
+      expect.arrayContaining([expect.stringContaining('example.mp4')]),
+      expect.any(Function),
+    );
+    expect(res.body).toEqual({
+      filePath: '/videos/example.mp4',
+      runTimeSeconds: 660,
+    });
+  });
+
+  it('rejects a missing filePath', async () => {
+    await supertest(createServer()).get('/run-time').expect(400);
+
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it('logs the error and returns a generic message when probing fails', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    const probeError = new Error('ffprobe exploded');
+    (execFile as unknown as jest.Mock).mockImplementation(
+      (_file, _args, callback) => callback(probeError),
+    );
+
+    const res = await supertest(createServer())
+      .get('/run-time')
+      .query({ filePath: '/videos/example.mp4' })
+      .expect(500);
+
+    expect(res.body).toEqual({ message: 'internal server error' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'GET /run-time failed:',
+      probeError,
+    );
+  });
+});

--- a/apps/video-api/tests/unit/title-cards.unit.test.ts
+++ b/apps/video-api/tests/unit/title-cards.unit.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import os from 'os';
+import { execFile } from 'child_process';
 import supertest from 'supertest';
 import * as videoDb from '@abbottland/video-db';
 import { hashFile } from '@abbottland/video-db';
@@ -7,6 +8,9 @@ import { createServer } from '../../src/server';
 import { initConfig } from '../../src/config';
 
 jest.mock('fs');
+jest.mock('child_process', () => ({
+  execFile: jest.fn(),
+}));
 // Partial mock: keep real value exports (e.g. titleCardSelectSchema, which
 // openapi.ts needs to build the doc at module-load time) and only mock the
 // query functions and hashFile under test here.
@@ -18,11 +22,18 @@ jest.mock('@abbottland/video-db', () => ({
   hashFile: jest.fn(),
 }));
 
+const mockRuntimeProbe = (stdout: string) => {
+  (execFile as unknown as jest.Mock).mockImplementation(
+    (_file, _args, callback) => callback(null, { stdout }),
+  );
+};
+
 const sampleTitleCard = {
   id: '123e4567-e89b-12d3-a456-426614174000',
   fileHash: 'deadbeef',
   filePath: '/videos/example.mp4',
   timestampSeconds: 30,
+  runTimeSeconds: 660,
   title: null,
   screenshotPath: null,
   createdAt: new Date(),
@@ -65,12 +76,14 @@ describe('POST /title-cards', () => {
 
     expect(res.body.message).toBe('file not found');
     expect(hashFile).not.toHaveBeenCalled();
+    expect(execFile).not.toHaveBeenCalled();
     expect(videoDb.upsertTitleCard).not.toHaveBeenCalled();
   });
 
-  it('hashes the file and upserts a title card', async () => {
+  it('hashes the file, probes its runtime, and upserts a title card', async () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
     (hashFile as jest.Mock).mockResolvedValue('deadbeef');
+    mockRuntimeProbe('660.000000\n');
     (videoDb.upsertTitleCard as jest.Mock).mockResolvedValue(sampleTitleCard);
 
     const res = await supertest(createServer())
@@ -81,19 +94,27 @@ describe('POST /title-cards', () => {
     expect(hashFile).toHaveBeenCalledWith(
       expect.stringContaining('example.mp4'),
     );
+    expect(execFile).toHaveBeenCalledWith(
+      'ffprobe',
+      expect.arrayContaining([expect.stringContaining('example.mp4')]),
+      expect.any(Function),
+    );
     expect(videoDb.upsertTitleCard).toHaveBeenCalledWith(undefined, {
       fileHash: 'deadbeef',
       filePath: '/videos/example.mp4',
       timestampSeconds: 30,
+      runTimeSeconds: 660,
       title: undefined,
       screenshotPath: undefined,
     });
     expect(res.body.fileHash).toBe('deadbeef');
+    expect(res.body.runTimeSeconds).toBe(660);
   });
 
   it('logs the error and returns a generic message when the upsert fails', async () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
     (hashFile as jest.Mock).mockResolvedValue('deadbeef');
+    mockRuntimeProbe('660.000000\n');
     const dbError = new Error('connection refused');
     (videoDb.upsertTitleCard as jest.Mock).mockRejectedValue(dbError);
 

--- a/apps/video-worker/Dockerfile
+++ b/apps/video-worker/Dockerfile
@@ -4,9 +4,10 @@ FROM ${BASE_IMAGE} AS builder
 FROM node:22-alpine AS runner
 
 # ffmpeg is the only thing video-worker needs beyond the shared Node.js
-# runner image; every other app builds off docker/pnpm-turbo.Dockerfile's
+# runner image; most other apps build off docker/pnpm-turbo.Dockerfile's
 # runner stage directly, but that stage is shared, so ffmpeg is installed
-# here instead of bloating every other app's image.
+# here instead of bloating every other app's image (see also video-api's
+# Dockerfile, which needs ffprobe for the same reason).
 RUN apk update && apk add --no-cache ffmpeg
 
 RUN addgroup --system --gid 1001 nodejs \

--- a/packages/video-db/drizzle/migrations/0003_left_human_robot.sql
+++ b/packages/video-db/drizzle/migrations/0003_left_human_robot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "title_cards" ADD COLUMN "run_time_seconds" integer;

--- a/packages/video-db/drizzle/migrations/meta/0003_snapshot.json
+++ b/packages/video-db/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,261 @@
+{
+  "id": "6df65913-06e8-4d3b-a609-f5ba3c2c1fd5",
+  "prevId": "61022a43-e2ad-4030-8c67-251f7f0ac4d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.video_jobs": {
+      "name": "video_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "video_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input_path": {
+          "name": "input_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_paths": {
+          "name": "output_paths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.title_cards": {
+      "name": "title_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_seconds": {
+          "name": "timestamp_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_time_seconds": {
+          "name": "run_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_path": {
+          "name": "screenshot_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "title_cards_file_hash_timestamp_seconds_unique": {
+          "name": "title_cards_file_hash_timestamp_seconds_unique",
+          "nullsNotDistinct": false,
+          "columns": ["file_hash", "timestamp_seconds"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_renames": {
+      "name": "file_renames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_path": {
+          "name": "original_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_file_path": {
+          "name": "suggested_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "file_rename_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_renames_file_hash_unique": {
+          "name": "file_renames_file_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["file_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.video_job_status": {
+      "name": "video_job_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed"]
+    },
+    "public.file_rename_status": {
+      "name": "file_rename_status",
+      "schema": "public",
+      "values": ["pending", "applied", "rejected"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/video-db/drizzle/migrations/meta/_journal.json
+++ b/packages/video-db/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784897890339,
       "tag": "0002_flawless_martin_li",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785163930121,
+      "tag": "0003_left_human_robot",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/video-db/src/queries/title-cards.ts
+++ b/packages/video-db/src/queries/title-cards.ts
@@ -8,7 +8,12 @@ import {
 
 export type UpsertTitleCardInput = Pick<
   NewTitleCard,
-  'fileHash' | 'filePath' | 'timestampSeconds' | 'title' | 'screenshotPath'
+  | 'fileHash'
+  | 'filePath'
+  | 'timestampSeconds'
+  | 'runTimeSeconds'
+  | 'title'
+  | 'screenshotPath'
 >;
 
 /**
@@ -28,6 +33,7 @@ export const upsertTitleCard = async (
       target: [titleCards.fileHash, titleCards.timestampSeconds],
       set: {
         filePath: input.filePath,
+        runTimeSeconds: input.runTimeSeconds,
         title: input.title,
         screenshotPath: input.screenshotPath,
       },

--- a/packages/video-db/src/schema/title-cards.ts
+++ b/packages/video-db/src/schema/title-cards.ts
@@ -23,6 +23,8 @@ export const titleCards = pgTable(
     /** Last known path the hash was computed from, relative to MEDIA_ROOT. Display/debugging only — not the identity key. */
     filePath: text('file_path').notNull(),
     timestampSeconds: integer('timestamp_seconds').notNull(),
+    /** Runtime of the whole file (not just this card), in seconds. Same value across every row sharing fileHash — probed once via ffprobe when the card is recorded. */
+    runTimeSeconds: integer('run_time_seconds'),
     /** Title text read off the card, if known. */
     title: text('title'),
     /** Path (relative to MEDIA_ROOT) of the screenshot that showed this title card, if any. */

--- a/packages/video-db/src/schema/title-cards.unit.test.ts
+++ b/packages/video-db/src/schema/title-cards.unit.test.ts
@@ -7,6 +7,7 @@ describe('titleCardSelectSchema', () => {
       fileHash: 'deadbeefcafe',
       filePath: '/tv_shows/Show A/S01E01.mp4',
       timestampSeconds: 128,
+      runTimeSeconds: 660,
       title: 'Pups Save a Toof',
       screenshotPath: '/screenshots/some-job-id/128.jpg',
       createdAt: new Date(),
@@ -17,12 +18,13 @@ describe('titleCardSelectSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('accepts null title and screenshotPath', () => {
+  it('accepts null runTimeSeconds, title, and screenshotPath', () => {
     const result = titleCardSelectSchema.safeParse({
       id: '123e4567-e89b-12d3-a456-426614174000',
       fileHash: 'deadbeefcafe',
       filePath: '/tv_shows/Show A/S01E01.mp4',
       timestampSeconds: 128,
+      runTimeSeconds: null,
       title: null,
       screenshotPath: null,
       createdAt: new Date(),
@@ -36,6 +38,7 @@ describe('titleCardSelectSchema', () => {
       id: '123e4567-e89b-12d3-a456-426614174000',
       filePath: '/tv_shows/Show A/S01E01.mp4',
       timestampSeconds: 128,
+      runTimeSeconds: null,
       title: null,
       screenshotPath: null,
       createdAt: new Date(),


### PR DESCRIPTION
## Summary
Stacked on #184 — depends on it merging first.

- New `GET /run-time?filePath=` — probes a video file's duration via ffprobe (resolved/existence-checked within MEDIA_ROOT, same pattern as `/hash`).
- `video-api` gets its own `Dockerfile` + `abctl.base.yml` (mirroring video-worker's two-stage build) so ffmpeg/ffprobe only bloats the images that actually need it.
- `title_cards` gets a `runTimeSeconds` column, probed once when a card is recorded. `POST /title-cards` now resolves the file once, then hashes and probes runtime in parallel. A file can have multiple title cards at different timestamps (e.g. a 20min video might have 2); `runTimeSeconds` is the same across all of them since it describes the file, not the individual card.
- Extracted `resolveFilePath` (resolve-within-MEDIA_ROOT + exists check) out of `resolve-and-hash-path.ts` so both the hash and runtime paths share one resolve step instead of duplicating it.

## Notable fix along the way
Integration tests now mock `child_process` globally in `jest.integration.setup.ts` rather than per-test-file: the setup file's own import of `server.ts` binds `execFile` at module-load time, before a later per-file `jest.mock('child_process')` would take effect — so a real `ffprobe` was executing against the non-video fixture file and failing before this was fixed.

## Test plan
- [x] `pnpm --filter @abbottland/video-db test:unit` — 9 passed
- [x] `pnpm --filter @abbottland/video-api test:unit` — 62 passed
- [x] `pnpm --filter @abbottland/video-api test:int` — 53 passed
- [x] Verified live against real ffprobe + a generated 12s clip: `/run-time` returned `12`, and a title card recorded against it carried `runTimeSeconds: 12`
- [x] lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6MtcZyAmkYmiQdSzS1ELh