### PR TITLE
video-worker: fix MEDIA_ROOT tv_shows path, retry AI client on transient failure

### DIFF
--- a/apps/video-worker/src/api/ai/ai-client.ts
+++ b/apps/video-worker/src/api/ai/ai-client.ts
@@ -20,20 +20,16 @@ type ChatCompletionResponse = {
   choices: { message: { content: string } }[];
 };
 
-/**
- * Sends a chat completion request to the configured OpenAI-compatible AI
- * API server (aiApiUrl, an LM Studio-style local server) and returns the
- * first choice's raw message content. Response-shape-agnostic on purpose —
- * callers that expect a particular JSON shape back (per their own system
- * prompt) parse the returned string themselves.
- */
-export const chatCompletion = async (
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 1000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const sendChatCompletionRequest = async (
+  url: string,
   request: ChatCompletionRequest,
 ): Promise<string> => {
-  const url = `${config.aiApiUrl}${CHAT_COMPLETIONS_PATH}`;
-
-  console.log(`🤖 POST ${url} ${request.model}`);
-
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -54,4 +50,41 @@ export const chatCompletion = async (
   }
 
   return content;
+};
+
+/**
+ * Sends a chat completion request to the configured OpenAI-compatible AI
+ * API server (aiApiUrl, an LM Studio-style local server) and returns the
+ * first choice's raw message content. Response-shape-agnostic on purpose —
+ * callers that expect a particular JSON shape back (per their own system
+ * prompt) parse the returned string themselves.
+ *
+ * Retries up to MAX_ATTEMPTS times with a linear backoff: aiApiUrl is a
+ * home LAN box on a separate subnet from the cluster, and transient
+ * connect timeouts there shouldn't fail an entire job — detectTitleCard
+ * caches per-screenshot responses, so a mid-job failure only costs the one
+ * in-flight request, not the whole batch, but retrying here avoids losing
+ * even that.
+ */
+export const chatCompletion = async (
+  request: ChatCompletionRequest,
+): Promise<string> => {
+  const url = `${config.aiApiUrl}${CHAT_COMPLETIONS_PATH}`;
+
+  console.log(`🤖 POST ${url} ${request.model}`);
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await sendChatCompletionRequest(url, request);
+    } catch (err) {
+      if (attempt === MAX_ATTEMPTS) throw err;
+
+      console.warn(
+        `⚠️  AI API request failed (attempt ${attempt}/${MAX_ATTEMPTS}), retrying: ${err instanceof Error ? err.message : err}`,
+      );
+      await sleep(RETRY_DELAY_MS * attempt);
+    }
+  }
+
+  throw new Error('unreachable');
 };

--- a/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/steps/list-season-files.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/steps/list-season-files.ts
@@ -5,12 +5,12 @@ import { resolveWithinRoot } from '../../../../lib/safe-path';
 import { JobProcessingError } from '../../../job-processing-error';
 import type { Step } from '../../pipeline';
 // Reused from the title-cards pipeline: both operations walk the same
-// `<MEDIA_ROOT>/Paw Patrol/Season <N>` layout, so the path helpers live in
+// `<MEDIA_ROOT>/media/tv_shows/Paw Patrol/Season <N>` layout, so the path helpers live in
 // one place rather than being duplicated per pipeline.
 import { seasonDirectoryRelPath } from '../../paw-patrol-title-cards/lib/paths';
 import type { PawPatrolFileSuggestionsContext } from '../context';
 
-/** Lists the episode files in `<MEDIA_ROOT>/Paw Patrol/Season <N>`. */
+/** Lists the episode files in `<MEDIA_ROOT>/media/tv_shows/Paw Patrol/Season <N>`. */
 export const listSeasonFiles: Step<PawPatrolFileSuggestionsContext> = async (
   ctx,
 ) => {

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/lib/paths.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/lib/paths.ts
@@ -1,20 +1,25 @@
 export const SHOW_DIRECTORY_NAME = 'Paw Patrol';
+const TV_SHOWS_DIRECTORY_NAME = 'media/tv_shows';
 const SCREENSHOTS_DIRECTORY_NAME = 'screenshots';
 
-/** `<series>/<season>`, relative to MEDIA_ROOT — e.g. `Paw Patrol/Season 3`. */
-export const seasonDirectoryRelPath = (seasonNumber: number): string =>
+/** `<series>/<season>`, e.g. `Paw Patrol/Season 3` — shared by the tv_shows and screenshots subtrees below. */
+const showSeasonRelPath = (seasonNumber: number): string =>
   `${SHOW_DIRECTORY_NAME}/Season ${seasonNumber}`;
+
+/** `media/tv_shows/<series>/<season>`, relative to MEDIA_ROOT — e.g. `media/tv_shows/Paw Patrol/Season 3`. */
+export const seasonDirectoryRelPath = (seasonNumber: number): string =>
+  `${TV_SHOWS_DIRECTORY_NAME}/${showSeasonRelPath(seasonNumber)}`;
 
 /**
  * `screenshots/<series>/<season>/<fileHash>`, relative to MEDIA_ROOT — kept
- * out of the episode directories themselves so generated screenshots never
- * mix in with source video files.
+ * out of the tv_shows subtree entirely (not just the episode directories)
+ * so generated screenshots never mix in with source video files.
  */
 export const screenshotDirectoryRelPath = (
   seasonNumber: number,
   fileHash: string,
 ): string =>
-  `${SCREENSHOTS_DIRECTORY_NAME}/${seasonDirectoryRelPath(seasonNumber)}/${fileHash}`;
+  `${SCREENSHOTS_DIRECTORY_NAME}/${showSeasonRelPath(seasonNumber)}/${fileHash}`;
 
 /** Recovers the sample timestamp encoded in a `<second>_<dimensions>.jpg` screenshot filename. */
 export const parseScreenshotTimestamp = (screenshotPath: string): number => {

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/steps/list-season-files.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/steps/list-season-files.ts
@@ -7,7 +7,7 @@ import type { Step } from '../../pipeline';
 import type { PawPatrolTitleCardsContext } from '../context';
 import { seasonDirectoryRelPath } from '../lib/paths';
 
-/** Lists the episode files in `<MEDIA_ROOT>/Paw Patrol/Season <N>`. */
+/** Lists the episode files in `<MEDIA_ROOT>/media/tv_shows/Paw Patrol/Season <N>`. */
 export const listSeasonFiles: Step<PawPatrolTitleCardsContext> = async (
   ctx,
 ) => {

--- a/apps/video-worker/tests/jest.integration.setup.ts
+++ b/apps/video-worker/tests/jest.integration.setup.ts
@@ -53,12 +53,17 @@ global.fetch = jest.fn(() =>
 export const MEDIA_ROOT = fs.mkdtempSync(
   path.join(os.tmpdir(), 'video-worker-media-'),
 );
-fs.mkdirSync(path.join(MEDIA_ROOT, 'Paw Patrol', 'Season 3'), {
-  recursive: true,
-});
+fs.mkdirSync(
+  path.join(MEDIA_ROOT, 'media', 'tv_shows', 'Paw Patrol', 'Season 3'),
+  {
+    recursive: true,
+  },
+);
 fs.writeFileSync(
   path.join(
     MEDIA_ROOT,
+    'media',
+    'tv_shows',
     'Paw Patrol',
     'Season 3',
     'Paw Patrol - S03E01 - Pups Save a Blimp.mp4',

--- a/apps/video-worker/tests/unit/ai-client.unit.test.ts
+++ b/apps/video-worker/tests/unit/ai-client.unit.test.ts
@@ -15,7 +15,12 @@ const jsonResponse = (body: unknown, ok = true, status = 200) => ({
 });
 
 describe('chatCompletion', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
@@ -56,16 +61,40 @@ describe('chatCompletion', () => {
   it('throws when the API responds with a non-ok status', async () => {
     mockFetch.mockResolvedValue(jsonResponse('server error', false, 500));
 
-    await expect(chatCompletion({ model: 'm', messages: [] })).rejects.toThrow(
-      'AI API request failed: 500',
-    );
+    const assertion = expect(
+      chatCompletion({ model: 'm', messages: [] }),
+    ).rejects.toThrow('AI API request failed: 500');
+    await jest.runAllTimersAsync();
+    await assertion;
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
   it('throws when the response has no message content', async () => {
     mockFetch.mockResolvedValue(jsonResponse({ choices: [] }));
 
-    await expect(chatCompletion({ model: 'm', messages: [] })).rejects.toThrow(
-      'no message content',
-    );
+    const assertion = expect(
+      chatCompletion({ model: 'm', messages: [] }),
+    ).rejects.toThrow('no message content');
+    await jest.runAllTimersAsync();
+    await assertion;
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries a transient fetch failure and succeeds once the API responds', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(
+        jsonResponse({ choices: [{ message: { content: 'recovered' } }] }),
+      );
+
+    const assertion = expect(
+      chatCompletion({ model: 'm', messages: [] }),
+    ).resolves.toBe('recovered');
+    await jest.runAllTimersAsync();
+    await assertion;
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/video-worker/tests/unit/insert-episode-title-cards.unit.test.ts
+++ b/apps/video-worker/tests/unit/insert-episode-title-cards.unit.test.ts
@@ -145,7 +145,7 @@ describe('insertEpisodeTitleCards', () => {
       {
         fileHash: 'hash-1',
         filePath:
-          'Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
+          'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
         timestampSeconds: 51,
         runTimeSeconds: 600,
         title: 'Pups Save a Blimp',

--- a/apps/video-worker/tests/unit/list-season-files.unit.test.ts
+++ b/apps/video-worker/tests/unit/list-season-files.unit.test.ts
@@ -60,16 +60,19 @@ describe('listSeasonFiles', () => {
       {
         filename: 'Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
         absPath:
-          '/media/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
+          '/media/media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
       },
       {
         filename: 'Paw Patrol - S03E02 - Pups Save a Goldrush.mp4',
         absPath:
-          '/media/Paw Patrol/Season 3/Paw Patrol - S03E02 - Pups Save a Goldrush.mp4',
+          '/media/media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E02 - Pups Save a Goldrush.mp4',
       },
     ]);
-    expect(fs.readdirSync).toHaveBeenCalledWith('/media/Paw Patrol/Season 3', {
-      withFileTypes: true,
-    });
+    expect(fs.readdirSync).toHaveBeenCalledWith(
+      '/media/media/tv_shows/Paw Patrol/Season 3',
+      {
+        withFileTypes: true,
+      },
+    );
   });
 });

--- a/apps/video-worker/tests/unit/paw-patrol-file-suggestions.unit.test.ts
+++ b/apps/video-worker/tests/unit/paw-patrol-file-suggestions.unit.test.ts
@@ -91,7 +91,7 @@ describe('runPawPatrolFileSuggestionsOperation', () => {
 
     expect(result.message).toBe('');
     expect(result.outputPaths).toEqual([
-      'Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
+      'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
     ]);
     expect(upsertFileRename).toHaveBeenCalledWith(
       {},

--- a/apps/video-worker/tests/unit/plex-filename.unit.test.ts
+++ b/apps/video-worker/tests/unit/plex-filename.unit.test.ts
@@ -58,14 +58,16 @@ describe('buildPlexEpisodeRelPath', () => {
   it('prefixes the season directory', () => {
     expect(
       buildPlexEpisodeRelPath(3, 1, 'Pups Save a Blimp', null, '.mp4'),
-    ).toBe('Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4');
+    ).toBe(
+      'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
+    );
   });
 
   it('carries the quality tag through', () => {
     expect(
       buildPlexEpisodeRelPath(3, 1, 'Pups Save a Blimp', 'HDTV-720p', '.mp4'),
     ).toBe(
-      'Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp [HDTV-720p].mp4',
+      'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp [HDTV-720p].mp4',
     );
   });
 });

--- a/apps/video-worker/tests/unit/save-suggestions.unit.test.ts
+++ b/apps/video-worker/tests/unit/save-suggestions.unit.test.ts
@@ -63,7 +63,7 @@ describe('saveSuggestions', () => {
         {
           filename: 'e01.mp4',
           absPath: '/media/e01.mp4',
-          suggestedFilePath: 'Paw Patrol/Season 3/x.mp4',
+          suggestedFilePath: 'media/tv_shows/Paw Patrol/Season 3/x.mp4',
         },
       ],
     });
@@ -82,7 +82,7 @@ describe('saveSuggestions', () => {
           absPath: '/media/random-name.mp4',
           hash: 'hash-1',
           suggestedFilePath:
-            'Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
+            'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
           sourceTitleCardTitles: ['Pups Save a Blimp'],
         },
       ],
@@ -94,16 +94,16 @@ describe('saveSuggestions', () => {
       {},
       {
         fileHash: 'hash-1',
-        originalFilePath: 'Paw Patrol/Season 3/random-name.mp4',
+        originalFilePath: 'media/tv_shows/Paw Patrol/Season 3/random-name.mp4',
         suggestedFilePath:
-          'Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
+          'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
         secondSuggestedFilePath: undefined,
         splitAtSeconds: undefined,
         sourceTitleCardTitles: ['Pups Save a Blimp'],
       },
     );
     expect(result.outputPaths).toEqual([
-      'Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
+      'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E01 - Pups Save a Blimp.mp4',
     ]);
   });
 
@@ -118,9 +118,9 @@ describe('saveSuggestions', () => {
           absPath: '/media/random-name.mp4',
           hash: 'hash-1',
           suggestedFilePath:
-            'Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
+            'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
           secondSuggestedFilePath:
-            'Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien.mp4',
+            'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien.mp4',
           splitAtSeconds: 660,
           sourceTitleCardTitles: [
             'Pups Save a Goldrush',
@@ -136,11 +136,11 @@ describe('saveSuggestions', () => {
       {},
       {
         fileHash: 'hash-1',
-        originalFilePath: 'Paw Patrol/Season 3/random-name.mp4',
+        originalFilePath: 'media/tv_shows/Paw Patrol/Season 3/random-name.mp4',
         suggestedFilePath:
-          'Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
+          'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
         secondSuggestedFilePath:
-          'Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien.mp4',
+          'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien.mp4',
         splitAtSeconds: 660,
         sourceTitleCardTitles: [
           'Pups Save a Goldrush',
@@ -149,8 +149,8 @@ describe('saveSuggestions', () => {
       },
     );
     expect(result.outputPaths).toEqual([
-      'Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
-      'Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien.mp4',
+      'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
+      'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien.mp4',
     ]);
   });
 });

--- a/apps/video-worker/tests/unit/suggest-filenames.unit.test.ts
+++ b/apps/video-worker/tests/unit/suggest-filenames.unit.test.ts
@@ -125,7 +125,7 @@ describe('suggestFilenames', () => {
       const result = await suggestFilenames(context);
 
       expect(result.episodes[0].suggestedFilePath).toBe(
-        'Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
+        'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
       );
       expect(result.episodes[0].sourceTitleCardTitles).toEqual([
         'Pups Save a Goldrush',
@@ -159,7 +159,7 @@ describe('suggestFilenames', () => {
       const result = await suggestFilenames(context);
 
       expect(result.episodes[0].suggestedFilePath).toBe(
-        'Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush [WEBDL-1080p].mp4',
+        'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush [WEBDL-1080p].mp4',
       );
     });
   });
@@ -231,10 +231,10 @@ describe('suggestFilenames', () => {
       const result = await suggestFilenames(context);
 
       expect(result.episodes[0].suggestedFilePath).toBe(
-        'Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
+        'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush.mp4',
       );
       expect(result.episodes[0].secondSuggestedFilePath).toBe(
-        'Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien.mp4',
+        'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien.mp4',
       );
       expect(result.episodes[0].splitAtSeconds).toBe(658.6);
       expect(result.episodes[0].sourceTitleCardTitles).toEqual([
@@ -333,10 +333,10 @@ describe('suggestFilenames', () => {
       const result = await suggestFilenames(context);
 
       expect(result.episodes[0].suggestedFilePath).toBe(
-        'Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush [HDTV-720p].mp4',
+        'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E18 - Pups Save a Goldrush [HDTV-720p].mp4',
       );
       expect(result.episodes[0].secondSuggestedFilePath).toBe(
-        'Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien [HDTV-720p].mp4',
+        'media/tv_shows/Paw Patrol/Season 3/Paw Patrol - S03E19 - Pups Save a Space Alien [HDTV-720p].mp4',
       );
     });
   });


### PR DESCRIPTION
## Summary

- Fix `seasonDirectoryRelPath` to nest under `media/tv_shows/` instead of assuming shows live directly at `<MEDIA_ROOT>/<Show>/Season N`. Verified the real remote layout via `kubectl exec` into the video-worker pod: `/media` (mount) → `media/{movies,tv_shows}` + `screenshots`. Lets `MEDIA_ROOT` be set to the clean mount root (`/media`) instead of the `/media/media/tv_shows` workaround. Screenshots path unaffected (stays at `<MEDIA_ROOT>/screenshots/...`).
- Local `/home/vscode/media` test fixtures restructured to match (`Paw Patrol/` → `media/tv_shows/Paw Patrol/`).
- `chatCompletion` (AI client) now retries transient fetch failures (3 attempts, linear backoff) — `aiApiUrl` (LM Studio) sits on a different subnet than the cluster nodes and occasionally fails the TCP connect within undici's 10s default, which was killing the entire title-cards job on one blip. `detectTitleCard` already caches responses per screenshot, so retrying here is cheap.

## Test plan

- [x] `pnpm --filter @abbottland/video-worker test` (133 unit + 6 integration, all passing)
- [ ] Set remote `MEDIA_ROOT=/media` and confirm `paw_patrol_title_cards`/`paw_patrol_file_suggestions` jobs resolve paths correctly
- [ ] Confirm AI client survives a transient LM Studio connect timeout without failing the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jtrcom7pQ2KpQiciWX9mZ