### PR TITLE
Add video processing subsystem (video-api, video-worker, video-db) + home-hud UI

### DIFF
--- a/apps/home-hud/src/app/components/HomeClient.tsx
+++ b/apps/home-hud/src/app/components/HomeClient.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Typography } from '@abbottland/fui-components';
+import type { AiStatus, VideoJob } from '../jobs/lib/video-api';
+import type { TitleCard } from '../title-cards/lib/video-api';
+import type { FileRename } from '../file-renames/lib/video-api';
+import { Counter } from './Counter';
+import { Footer } from './Footer';
+import { HomeSummaryPanels } from './HomeSummaryPanels';
+
+interface HomeClientProps {
+  jobs: VideoJob[] | null;
+  aiStatus: AiStatus | null;
+  titleCards: TitleCard[] | null;
+  fileRenames: FileRename[] | null;
+}
+
+export function HomeClient({
+  jobs,
+  aiStatus,
+  titleCards,
+  fileRenames,
+}: HomeClientProps) {
+  return (
+    <main className="flex min-h-screen flex-col bg-neutral-800">
+      <div className="flex flex-1 flex-col gap-10 px-8 py-10">
+        <div className="flex flex-col items-center gap-4">
+          <Typography variant="h1" component="h1">
+            Home HUD
+          </Typography>
+          <Typography variant="h3" component="h3">
+            your house, at a glance
+          </Typography>
+          <Counter />
+        </div>
+
+        <HomeSummaryPanels
+          jobs={jobs}
+          aiStatus={aiStatus}
+          titleCards={titleCards}
+          fileRenames={fileRenames}
+        />
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/apps/home-hud/src/app/components/HomeSummaryPanels.tsx
+++ b/apps/home-hud/src/app/components/HomeSummaryPanels.tsx
@@ -1,0 +1,288 @@
+import Link from 'next/link';
+import {
+  Badge,
+  type BadgeColor,
+  Panel,
+  SegmentedProgressBar,
+  TransparentPanel,
+  Typography,
+} from '@abbottland/fui-components';
+import type { AiStatus, VideoJob, VideoJobStatus } from '../jobs/lib/video-api';
+import type { TitleCard } from '../title-cards/lib/video-api';
+import type {
+  FileRename,
+  FileRenameStatus,
+} from '../file-renames/lib/video-api';
+
+const jobStatusColor: Record<VideoJobStatus, BadgeColor> = {
+  pending: 'warning',
+  processing: 'secondary',
+  completed: 'success',
+  failed: 'error',
+};
+
+const JOB_STATUSES: VideoJobStatus[] = [
+  'pending',
+  'processing',
+  'completed',
+  'failed',
+];
+
+const operationLabels: Record<string, string> = {
+  paw_patrol_title_cards: 'Title Cards',
+  paw_patrol_file_suggestions: 'File Suggestions',
+  paw_patrol_apply_file_renames: 'Apply Renames',
+};
+
+const fileRenameStatusColor: Record<FileRenameStatus, BadgeColor> = {
+  pending: 'warning',
+  applied: 'success',
+  rejected: 'error',
+};
+
+const FILE_RENAME_STATUSES: FileRenameStatus[] = [
+  'pending',
+  'applied',
+  'rejected',
+];
+
+const FIRST_SEASON = 1;
+const LAST_SEASON = 13;
+
+/** Pulls the season number out of a `<Show>/Season <N>/<file>` path. */
+function extractSeasonNumber(filePath: string): number | null {
+  const match = filePath.match(/Season (\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+// Fixed locale/timeZone so server and client render identical text — a
+// locale-dependent format (e.g. toLocaleString()) mismatches across the
+// SSR/hydration boundary whenever the server and browser timezones differ.
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+  timeZone: 'UTC',
+});
+
+function formatDate(iso: string): string {
+  return dateFormatter.format(new Date(iso));
+}
+
+function mostRecentBy<T extends { createdAt: string }>(
+  items: T[] | null,
+): T | null {
+  if (!items || items.length === 0) return null;
+  return items.reduce((latest, item) =>
+    new Date(item.createdAt) > new Date(latest.createdAt) ? item : latest,
+  );
+}
+
+interface HomeSummaryPanelsProps {
+  jobs: VideoJob[] | null;
+  aiStatus: AiStatus | null;
+  titleCards: TitleCard[] | null;
+  fileRenames: FileRename[] | null;
+}
+
+export function HomeSummaryPanels({
+  jobs,
+  aiStatus,
+  titleCards,
+  fileRenames,
+}: HomeSummaryPanelsProps) {
+  const totalJobs = jobs?.length ?? 0;
+  const jobCounts = Object.fromEntries(
+    JOB_STATUSES.map((status) => [
+      status,
+      jobs?.filter((job) => job.status === status).length ?? 0,
+    ]),
+  ) as Record<VideoJobStatus, number>;
+  const mostRecentJob = mostRecentBy(jobs);
+
+  const totalTitleCards = titleCards?.length ?? 0;
+  const seasonsCovered = new Set(
+    (titleCards ?? [])
+      .map((titleCard) => extractSeasonNumber(titleCard.filePath))
+      .filter((season): season is number => season !== null),
+  );
+  const highestSeasonCovered = seasonsCovered.size
+    ? Math.max(...seasonsCovered)
+    : 0;
+  const identifiedCount =
+    titleCards?.filter((titleCard) => titleCard.title !== null).length ?? 0;
+  const mostRecentTitleCard = mostRecentBy(titleCards);
+
+  const totalFileRenames = fileRenames?.length ?? 0;
+  const fileRenameCounts = Object.fromEntries(
+    FILE_RENAME_STATUSES.map((status) => [
+      status,
+      fileRenames?.filter((fileRename) => fileRename.status === status)
+        .length ?? 0,
+    ]),
+  ) as Record<FileRenameStatus, number>;
+  const mostRecentFileRename = mostRecentBy(fileRenames);
+
+  const aiOnline = aiStatus?.online ?? false;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <TransparentPanel
+        color="dark"
+        className="flex flex-wrap items-center justify-between gap-4"
+      >
+        <Typography variant="h6" component="h2" className="text-neutral-400">
+          System Status
+        </Typography>
+        <div className="flex flex-col items-end gap-2">
+          <div className="flex items-center gap-2">
+            <Badge color={aiOnline ? 'success' : 'error'}>
+              AI Server:{' '}
+              {aiStatus === null ? 'Unknown' : aiOnline ? 'Online' : 'Offline'}
+            </Badge>
+            {aiStatus?.online && aiStatus.models.length > 0 && (
+              <Badge color="dark">
+                {aiStatus.models.length} model
+                {aiStatus.models.length === 1 ? '' : 's'} loaded
+              </Badge>
+            )}
+          </div>
+          <div className="flex items-center gap-4">
+            <Badge color="dark">{totalJobs} jobs</Badge>
+            <Badge color="dark">{totalTitleCards} title cards</Badge>
+            <Badge color="dark">{totalFileRenames} renames</Badge>
+          </div>
+        </div>
+      </TransparentPanel>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        <Link href="/jobs" className="block">
+          <Panel color="primary" className="flex h-full flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <Typography variant="h5" component="h2">
+                Video Jobs
+              </Typography>
+              <Typography variant="h3" component="span">
+                {totalJobs}
+              </Typography>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {JOB_STATUSES.map((status) => (
+                <Badge key={status} color={jobStatusColor[status]}>
+                  {status}: {jobCounts[status]}
+                </Badge>
+              ))}
+            </div>
+
+            <div className="mt-auto flex flex-col gap-1 border-t border-neutral-50/20 pt-3">
+              <Typography variant="small" className="text-neutral-300">
+                Most Recent
+              </Typography>
+              {mostRecentJob ? (
+                <>
+                  <Typography variant="body2">
+                    {operationLabels[mostRecentJob.operation] ??
+                      mostRecentJob.operation}
+                  </Typography>
+                  <Typography variant="caption" className="text-neutral-300">
+                    {formatDate(mostRecentJob.createdAt)}
+                  </Typography>
+                </>
+              ) : (
+                <Typography variant="body2" className="text-neutral-300">
+                  No jobs yet
+                </Typography>
+              )}
+            </div>
+          </Panel>
+        </Link>
+
+        <Link href="/title-cards" className="block">
+          <Panel color="secondary" className="flex h-full flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <Typography variant="h5" component="h2">
+                Title Cards
+              </Typography>
+              <Typography variant="h3" component="span">
+                {totalTitleCards}
+              </Typography>
+            </div>
+
+            <Typography variant="caption" className="text-neutral-200">
+              {identifiedCount} of {totalTitleCards} identified
+            </Typography>
+
+            <SegmentedProgressBar
+              totalSegments={LAST_SEASON - FIRST_SEASON + 1}
+              currentIndex={highestSeasonCovered}
+              showLabel
+              labelText="Season Coverage"
+              showIndex
+            />
+
+            <div className="mt-auto flex flex-col gap-1 border-t border-neutral-50/20 pt-3">
+              <Typography variant="small" className="text-neutral-300">
+                Most Recent
+              </Typography>
+              {mostRecentTitleCard ? (
+                <>
+                  <Typography variant="body2">
+                    {mostRecentTitleCard.title ?? 'No title detected'}
+                  </Typography>
+                  <Typography variant="caption" className="text-neutral-300">
+                    {formatDate(mostRecentTitleCard.createdAt)}
+                  </Typography>
+                </>
+              ) : (
+                <Typography variant="body2" className="text-neutral-300">
+                  No title cards yet
+                </Typography>
+              )}
+            </div>
+          </Panel>
+        </Link>
+
+        <Link href="/file-renames" className="block">
+          <Panel color="accent-falcon" className="flex h-full flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <Typography variant="h5" component="h2">
+                File Renames
+              </Typography>
+              <Typography variant="h3" component="span">
+                {totalFileRenames}
+              </Typography>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {FILE_RENAME_STATUSES.map((status) => (
+                <Badge key={status} color={fileRenameStatusColor[status]}>
+                  {status}: {fileRenameCounts[status]}
+                </Badge>
+              ))}
+            </div>
+
+            <div className="mt-auto flex flex-col gap-1 border-t border-neutral-50/20 pt-3">
+              <Typography variant="small" className="text-neutral-300">
+                Most Recent
+              </Typography>
+              {mostRecentFileRename ? (
+                <>
+                  <Typography variant="body2" className="truncate">
+                    {mostRecentFileRename.originalFilePath}
+                  </Typography>
+                  <Typography variant="caption" className="text-neutral-300">
+                    {formatDate(mostRecentFileRename.createdAt)}
+                  </Typography>
+                </>
+              ) : (
+                <Typography variant="body2" className="text-neutral-300">
+                  No rename suggestions yet
+                </Typography>
+              )}
+            </div>
+          </Panel>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/home-hud/src/app/file-renames/FileRenamesClient.tsx
+++ b/apps/home-hud/src/app/file-renames/FileRenamesClient.tsx
@@ -25,7 +25,7 @@ import {
   Td,
   Typography,
 } from '@abbottland/fui-components';
-import { deleteFileRenamesForSeason } from './lib/actions';
+import { deleteFileRename, deleteFileRenamesForSeason } from './lib/actions';
 import type { FileRename, FileRenameStatus } from './lib/video-api';
 
 const fileRenameStatusColor: Record<FileRenameStatus, BadgeColor> = {
@@ -33,6 +33,8 @@ const fileRenameStatusColor: Record<FileRenameStatus, BadgeColor> = {
   applied: 'success',
   rejected: 'error',
 };
+
+const STATUS_OPTIONS: FileRenameStatus[] = ['pending', 'applied', 'rejected'];
 
 const PAGE_SIZE = 10;
 
@@ -83,15 +85,26 @@ export function FileRenamesClient({ fileRenames }: FileRenamesClientProps) {
   const [page, setPage] = useState(1);
   const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
   const [seasonMenuOpen, setSeasonMenuOpen] = useState(false);
+  const [selectedStatus, setSelectedStatus] = useState<FileRenameStatus | null>(
+    null,
+  );
+  const [statusMenuOpen, setStatusMenuOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [rowDeleting, setRowDeleting] = useState(false);
+  const [rowDeleteError, setRowDeleteError] = useState<string | null>(null);
 
-  const filteredFileRenames = fileRenames?.filter(
-    (fileRename) =>
-      selectedSeason === null ||
-      extractSeasonNumber(fileRename.originalFilePath) === selectedSeason,
-  );
+  const filteredFileRenames = fileRenames
+    ?.filter(
+      (fileRename) =>
+        (selectedSeason === null ||
+          extractSeasonNumber(fileRename.originalFilePath) ===
+            selectedSeason) &&
+        (selectedStatus === null || fileRename.status === selectedStatus),
+    )
+    .sort((a, b) => a.originalFilePath.localeCompare(b.originalFilePath));
 
   const totalPages = filteredFileRenames
     ? Math.max(1, Math.ceil(filteredFileRenames.length / PAGE_SIZE))
@@ -104,6 +117,28 @@ export function FileRenamesClient({ fileRenames }: FileRenamesClientProps) {
   function selectSeason(season: number | null) {
     setSelectedSeason(season);
     setPage(1);
+  }
+
+  function selectStatus(status: FileRenameStatus | null) {
+    setSelectedStatus(status);
+    setPage(1);
+  }
+
+  async function handleDeleteFileRename(id: string) {
+    setRowDeleting(true);
+    setRowDeleteError(null);
+
+    try {
+      await deleteFileRename(id);
+      setConfirmDeleteId(null);
+      router.refresh();
+    } catch (err) {
+      setRowDeleteError(
+        err instanceof Error ? err.message : 'Failed to delete file rename',
+      );
+    } finally {
+      setRowDeleting(false);
+    }
   }
 
   async function deleteSeason() {
@@ -149,6 +184,27 @@ export function FileRenamesClient({ fileRenames }: FileRenamesClientProps) {
                   onSelect={() => selectSeason(season)}
                 >
                   Season {season}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <DropdownMenu open={statusMenuOpen} onOpenChange={setStatusMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <OutlinedButton size="small">
+                Status: {selectedStatus ?? 'All'}
+              </OutlinedButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent label="Filter by Status">
+              <DropdownMenuItem onSelect={() => selectStatus(null)}>
+                All Statuses
+              </DropdownMenuItem>
+              {STATUS_OPTIONS.map((status) => (
+                <DropdownMenuItem
+                  key={status}
+                  onSelect={() => selectStatus(status)}
+                >
+                  {status}
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>
@@ -201,6 +257,11 @@ export function FileRenamesClient({ fileRenames }: FileRenamesClientProps) {
             Failed to load file renames from video-api.
           </Typography>
         )}
+        {rowDeleteError && (
+          <Typography variant="body2" className="text-error-400">
+            {rowDeleteError}
+          </Typography>
+        )}
         {fileRenames?.length === 0 && (
           <Typography variant="body1">No rename suggestions yet.</Typography>
         )}
@@ -208,7 +269,7 @@ export function FileRenamesClient({ fileRenames }: FileRenamesClientProps) {
           fileRenames.length > 0 &&
           filteredFileRenames?.length === 0 && (
             <Typography variant="body1">
-              No rename suggestions for Season {selectedSeason}.
+              No rename suggestions match the current filters.
             </Typography>
           )}
         {pageFileRenames && pageFileRenames.length > 0 && (
@@ -224,6 +285,7 @@ export function FileRenamesClient({ fileRenames }: FileRenamesClientProps) {
                     <Th>Status</Th>
                     <Th>Created</Th>
                     <Th>Applied</Th>
+                    <Th>Actions</Th>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -268,6 +330,49 @@ export function FileRenamesClient({ fileRenames }: FileRenamesClientProps) {
                         {fileRename.appliedAt
                           ? formatDate(fileRename.appliedAt)
                           : '—'}
+                      </Td>
+                      <Td>
+                        <Modal
+                          open={confirmDeleteId === fileRename.id}
+                          onOpenChange={(open) =>
+                            setConfirmDeleteId(open ? fileRename.id : null)
+                          }
+                        >
+                          <ModalTrigger asChild>
+                            <Button size="small" color="error">
+                              Delete
+                            </Button>
+                          </ModalTrigger>
+                          <ModalContent color="secondary">
+                            <ModalTitle>
+                              Delete this rename suggestion?
+                            </ModalTitle>
+                            <ModalDescription>
+                              Permanently deletes the rename suggestion for{' '}
+                              {fileRename.originalFilePath}. This cannot be
+                              undone.
+                            </ModalDescription>
+                            <div className="mt-4 flex justify-end gap-3">
+                              <OutlinedButton
+                                size="small"
+                                disabled={rowDeleting}
+                                onClick={() => setConfirmDeleteId(null)}
+                              >
+                                Cancel
+                              </OutlinedButton>
+                              <Button
+                                size="small"
+                                color="error"
+                                disabled={rowDeleting}
+                                onClick={() =>
+                                  void handleDeleteFileRename(fileRename.id)
+                                }
+                              >
+                                {rowDeleting ? 'Deleting…' : 'Delete'}
+                              </Button>
+                            </div>
+                          </ModalContent>
+                        </Modal>
                       </Td>
                     </TableRow>
                   ))}

--- a/apps/home-hud/src/app/file-renames/lib/actions.ts
+++ b/apps/home-hud/src/app/file-renames/lib/actions.ts
@@ -2,6 +2,19 @@
 
 const VIDEO_API_URL = process.env.VIDEO_API_URL ?? 'http://localhost:4002';
 
+export async function deleteFileRename(id: string): Promise<void> {
+  const res = await fetch(`${VIDEO_API_URL}/file-renames/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `video-api DELETE /file-renames/${id} returned ${res.status}: ${body}`,
+    );
+  }
+}
+
 export async function deleteFileRenamesForSeason(
   seasonNumber: number,
 ): Promise<void> {

--- a/apps/home-hud/src/app/jobs/JobsClient.tsx
+++ b/apps/home-hud/src/app/jobs/JobsClient.tsx
@@ -57,11 +57,12 @@ const operationLabels: Record<JobOperation, string> = {
 const operationNeedsSeason = (operation: JobOperation): boolean =>
   operation !== 'paw_patrol_apply_file_renames';
 
-// Only file_suggestions calls out to the AI per-episode-matching step in a
-// way where swapping models job-to-job is useful — title_cards' detection
-// step and apply_file_renames don't take a model input at all.
+// file_suggestions (episode-matching) and title_cards (title-card detection)
+// both call out to the AI in a way where swapping models job-to-job is
+// useful — apply_file_renames doesn't take a model input at all.
 const operationSupportsModelOverride = (operation: JobOperation): boolean =>
-  operation === 'paw_patrol_file_suggestions';
+  operation === 'paw_patrol_file_suggestions' ||
+  operation === 'paw_patrol_title_cards';
 
 // Fixed locale/timeZone so server and client render identical text — a
 // locale-dependent format (e.g. toLocaleString()) mismatches across the
@@ -134,10 +135,14 @@ export function JobsClient({ jobs, aiStatus }: JobsClientProps) {
         </Badge>
         {aiStatus?.online &&
           (aiStatus.models.length > 0 ? (
-            aiStatus.models.map((model) => (
-              <Badge key={model} color="dark">
-                {model}
-              </Badge>
+            aiStatus.models.map((modelName) => (
+              <OutlinedButton
+                key={modelName}
+                size="small"
+                onClick={() => setModel(modelName)}
+              >
+                {modelName}
+              </OutlinedButton>
             ))
           ) : (
             <Typography variant="body2" className="text-neutral-400">
@@ -189,6 +194,7 @@ export function JobsClient({ jobs, aiStatus }: JobsClientProps) {
               placeholder="Model (default)"
               value={model}
               onChange={(e) => setModel(e.target.value)}
+              color="primary"
               className="w-56"
             />
           )}

--- a/apps/home-hud/src/app/page.tsx
+++ b/apps/home-hud/src/app/page.tsx
@@ -1,22 +1,49 @@
-'use client';
+import { HomeClient } from './components/HomeClient';
+import {
+  getAiStatus,
+  getJobs,
+  type AiStatus,
+  type VideoJob,
+} from './jobs/lib/video-api';
+import { getTitleCards, type TitleCard } from './title-cards/lib/video-api';
+import { getFileRenames, type FileRename } from './file-renames/lib/video-api';
 
-import { Typography } from '@abbottland/fui-components';
-import { Counter } from './components/Counter';
-import { Footer } from './components/Footer';
+export default async function Home() {
+  let jobs: VideoJob[] | null = null;
+  let aiStatus: AiStatus | null = null;
+  let titleCards: TitleCard[] | null = null;
+  let fileRenames: FileRename[] | null = null;
 
-export default function Home() {
+  try {
+    jobs = await getJobs();
+  } catch (err) {
+    console.error('Failed to load jobs from video-api:', err);
+  }
+
+  try {
+    aiStatus = await getAiStatus();
+  } catch (err) {
+    console.error('Failed to load AI status from video-api:', err);
+  }
+
+  try {
+    titleCards = await getTitleCards();
+  } catch (err) {
+    console.error('Failed to load title cards from video-api:', err);
+  }
+
+  try {
+    fileRenames = await getFileRenames();
+  } catch (err) {
+    console.error('Failed to load file renames from video-api:', err);
+  }
+
   return (
-    <main className="flex min-h-screen flex-col bg-neutral-800">
-      <div className="flex flex-1 flex-col items-center justify-center gap-4">
-        <Typography variant="h1" component="h1">
-          Home HUD
-        </Typography>
-        <Typography variant="h3" component="h3">
-          your house, at a glance
-        </Typography>
-        <Counter />
-      </div>
-      <Footer />
-    </main>
+    <HomeClient
+      jobs={jobs}
+      aiStatus={aiStatus}
+      titleCards={titleCards}
+      fileRenames={fileRenames}
+    />
   );
 }

--- a/apps/video-api/src/controllers/file-renames.ts
+++ b/apps/video-api/src/controllers/file-renames.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import {
+  deleteFileRenameById,
   deleteFileRenamesBySeason,
   listFileRenames as listFileRenamesQuery,
 } from '@abbottland/video-db';
@@ -19,6 +20,22 @@ export const listFileRenames = async (req: Request, res: Response) => {
     res.status(200).json({ fileRenames });
   } catch (err) {
     console.error('GET /file-renames failed:', err);
+    res.status(500).json({ message: 'internal server error' });
+  }
+};
+
+export const deleteFileRename = async (req: Request, res: Response) => {
+  // req.params is already validated/typed by the validateParams(fileRenameIdParamsSchema) middleware.
+  try {
+    const fileRename = await deleteFileRenameById(db, req.params.id);
+
+    if (!fileRename) {
+      return res.status(404).json({ message: 'file rename not found' });
+    }
+
+    res.status(200).json(fileRename);
+  } catch (err) {
+    console.error(`DELETE /file-renames/${req.params.id} failed:`, err);
     res.status(500).json({ message: 'internal server error' });
   }
 };

--- a/apps/video-api/src/schemas/file-renames.ts
+++ b/apps/video-api/src/schemas/file-renames.ts
@@ -23,3 +23,7 @@ export const deleteFileRenamesQuerySchema = z.object({
 export type DeleteFileRenamesQuery = z.infer<
   typeof deleteFileRenamesQuerySchema
 >;
+
+export const fileRenameIdParamsSchema = z.object({
+  id: z.uuid('id must be a valid UUID'),
+});

--- a/apps/video-api/src/schemas/jobs.ts
+++ b/apps/video-api/src/schemas/jobs.ts
@@ -18,6 +18,11 @@ const pawPatrolTitleCardsJobSchema = z.object({
       description: 'Paw Patrol season number to generate title cards for',
       example: 3,
     }),
+    model: z.string().min(1).optional().meta({
+      description:
+        'AI model to request for this job’s title-card detection calls, overriding the worker’s configured default',
+      example: 'qwen/qwen3-vl-8b-instruct',
+    }),
   }),
 });
 

--- a/apps/video-api/src/server.ts
+++ b/apps/video-api/src/server.ts
@@ -11,13 +11,18 @@ import {
 } from '@abbottland/express';
 import { config } from './config';
 import { getAiStatusRoute } from './controllers/ai';
-import { deleteFileRenames, listFileRenames } from './controllers/file-renames';
+import {
+  deleteFileRename,
+  deleteFileRenames,
+  listFileRenames,
+} from './controllers/file-renames';
 import { getJob, listJobs, postJob } from './controllers/jobs';
 import { getReady } from './controllers/ready';
 import { deleteTitleCard, listTitleCards } from './controllers/title-cards';
 import { openApiSpec } from './openapi';
 import {
   deleteFileRenamesQuerySchema,
+  fileRenameIdParamsSchema,
   listFileRenamesQuerySchema,
 } from './schemas/file-renames';
 import {
@@ -66,6 +71,11 @@ export const createServer = (): Express => {
       '/file-renames',
       validateQuery(deleteFileRenamesQuerySchema),
       deleteFileRenames,
+    )
+    .delete(
+      '/file-renames/:id',
+      validateParams(fileRenameIdParamsSchema),
+      deleteFileRename,
     );
 
   configureErrorHandler(app);

--- a/apps/video-api/tests/unit/file-renames.unit.test.ts
+++ b/apps/video-api/tests/unit/file-renames.unit.test.ts
@@ -9,6 +9,7 @@ jest.mock('@abbottland/video-db', () => ({
   ...jest.requireActual('@abbottland/video-db'),
   listFileRenames: jest.fn(),
   deleteFileRenamesBySeason: jest.fn(),
+  deleteFileRenameById: jest.fn(),
 }));
 
 describe('GET /file-renames', () => {
@@ -137,6 +138,69 @@ describe('DELETE /file-renames', () => {
     expect(res.body).toEqual({ message: 'internal server error' });
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'DELETE /file-renames failed:',
+      dbError,
+    );
+  });
+});
+
+describe('DELETE /file-renames/:id', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  const VALID_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.resetAllMocks();
+  });
+
+  it('rejects a non-UUID id without touching the database', async () => {
+    const res = await supertest(createServer())
+      .delete('/file-renames/not-a-uuid')
+      .expect(400);
+
+    expect(res.body.message).toBe('Invalid request parameters');
+    expect(videoDb.deleteFileRenameById).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when no file rename matches the id', async () => {
+    (videoDb.deleteFileRenameById as jest.Mock).mockResolvedValue(undefined);
+
+    const res = await supertest(createServer())
+      .delete(`/file-renames/${VALID_ID}`)
+      .expect(404);
+
+    expect(res.body).toEqual({ message: 'file rename not found' });
+  });
+
+  it('deletes the file rename and returns it', async () => {
+    const deleted = { id: VALID_ID, status: 'pending' };
+    (videoDb.deleteFileRenameById as jest.Mock).mockResolvedValue(deleted);
+
+    const res = await supertest(createServer())
+      .delete(`/file-renames/${VALID_ID}`)
+      .expect(200);
+
+    expect(videoDb.deleteFileRenameById).toHaveBeenCalledWith(
+      undefined,
+      VALID_ID,
+    );
+    expect(res.body).toEqual(deleted);
+  });
+
+  it('logs the error and returns a generic message when deletion fails', async () => {
+    const dbError = new Error('connection refused');
+    (videoDb.deleteFileRenameById as jest.Mock).mockRejectedValue(dbError);
+
+    const res = await supertest(createServer())
+      .delete(`/file-renames/${VALID_ID}`)
+      .expect(500);
+
+    expect(res.body).toEqual({ message: 'internal server error' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `DELETE /file-renames/${VALID_ID} failed:`,
       dbError,
     );
   });

--- a/apps/video-worker/src/api/ai/ai-client.ts
+++ b/apps/video-worker/src/api/ai/ai-client.ts
@@ -109,6 +109,48 @@ const sendChatCompletionRequest = async (
   }
 };
 
+const describeMessageContent = (content: ChatMessage['content']): string => {
+  if (typeof content === 'string') return content;
+
+  return content
+    .map((part) =>
+      part.type === 'text'
+        ? part.text
+        : `[image omitted, ${part.image_url.url.length} chars]`,
+    )
+    .join('\n');
+};
+
+const describeMessages = (messages: ChatMessage[]): string =>
+  messages
+    .map(
+      (message) =>
+        `--- ${message.role} ---\n${describeMessageContent(message.content)}`,
+    )
+    .join('\n\n');
+
+/**
+ * Parses an AI response as JSON, dumping the full prompt and raw response to
+ * the logs before rethrowing on failure — the model occasionally wraps its
+ * JSON in a markdown code fence or adds stray text despite being told not
+ * to, and the bare SyntaxError from JSON.parse alone doesn't say what it
+ * actually sent back, making that failure mode otherwise undiagnosable
+ * after the fact.
+ */
+export const parseJsonResponse = <T>(
+  request: ChatCompletionRequest,
+  content: string,
+): T => {
+  try {
+    return JSON.parse(content) as T;
+  } catch (err) {
+    console.error(
+      `❌ AI response was not valid JSON (model=${request.model})\n${describeMessages(request.messages)}\n--- response ---\n${content}`,
+    );
+    throw err;
+  }
+};
+
 /**
  * Sends a chat completion request to the configured OpenAI-compatible AI
  * API server (aiApiUrl, an LM Studio-style local server) and returns the

--- a/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/refine-split-point.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/refine-split-point.ts
@@ -50,6 +50,7 @@ export const refineSplitPoint = async (
   fileHash: string,
   episodeAbsPath: string,
   coarseTimestampSeconds: number,
+  model: string,
 ): Promise<number> => {
   const screenshotDirRelPath = screenshotDirectoryRelPath(
     seasonNumber,
@@ -101,6 +102,7 @@ export const refineSplitPoint = async (
       outputRelPath,
       imageBase64,
       SCREENSHOT_MIME_TYPE,
+      model,
     );
 
     if (!result.found) break;

--- a/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/suggest-double-episode.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/suggest-double-episode.ts
@@ -1,4 +1,8 @@
-import { chatCompletion } from '../../../../api/ai/ai-client';
+import {
+  chatCompletion,
+  parseJsonResponse,
+  type ChatCompletionRequest,
+} from '../../../../api/ai/ai-client';
 import type { SonarrEpisode } from '../../../../api/sonarr/sonarr-client';
 
 const SYSTEM_PROMPT = `You are a TV episode identification specialist for a Paw Patrol media library. Your only job is matching ONE video file that bundles TWO back-to-back episodes — a common release pattern for this show — to its two official episodes from Sonarr.
@@ -58,7 +62,7 @@ export const suggestDoubleEpisode = async (
   sonarrEpisodes: SonarrEpisode[],
   model: string,
 ): Promise<DoubleEpisodeMatchResult> => {
-  const content = await chatCompletion({
+  const request: ChatCompletionRequest = {
     model,
     messages: [
       { role: 'system', content: SYSTEM_PROMPT },
@@ -72,7 +76,8 @@ export const suggestDoubleEpisode = async (
         ),
       },
     ],
-  });
+  };
 
-  return JSON.parse(content) as DoubleEpisodeMatchResult;
+  const content = await chatCompletion(request);
+  return parseJsonResponse<DoubleEpisodeMatchResult>(request, content);
 };

--- a/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/suggest-single-episode.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/suggest-single-episode.ts
@@ -1,4 +1,8 @@
-import { chatCompletion } from '../../../../api/ai/ai-client';
+import {
+  chatCompletion,
+  parseJsonResponse,
+  type ChatCompletionRequest,
+} from '../../../../api/ai/ai-client';
 import type { SonarrEpisode } from '../../../../api/sonarr/sonarr-client';
 
 const SYSTEM_PROMPT = `You are a TV episode identification specialist for a Paw Patrol media library. Your only job is matching ONE video file — which shows exactly one detected on-screen title card — to its single official episode from Sonarr.
@@ -48,7 +52,7 @@ export const suggestSingleEpisode = async (
   sonarrEpisodes: SonarrEpisode[],
   model: string,
 ): Promise<SingleEpisodeMatchResult> => {
-  const content = await chatCompletion({
+  const request: ChatCompletionRequest = {
     model,
     messages: [
       { role: 'system', content: SYSTEM_PROMPT },
@@ -57,7 +61,8 @@ export const suggestSingleEpisode = async (
         content: buildUserPrompt(filename, titleCardTitle, sonarrEpisodes),
       },
     ],
-  });
+  };
 
-  return JSON.parse(content) as SingleEpisodeMatchResult;
+  const content = await chatCompletion(request);
+  return parseJsonResponse<SingleEpisodeMatchResult>(request, content);
 };

--- a/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/steps/suggest-filenames.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/steps/suggest-filenames.ts
@@ -95,6 +95,7 @@ export const suggestFilenames: Step<PawPatrolFileSuggestionsContext> = async (
         episode.hash,
         episode.absPath,
         titleCards[1].timestampSeconds,
+        ctx.model,
       );
 
       return {

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/context.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/context.ts
@@ -10,6 +10,8 @@ import type { Episode } from './episode';
 export type PawPatrolTitleCardsContext = {
   job: VideoJob;
   seasonNumber: number;
+  /** AI model for title-card detection calls — job.parameters.model, falling back to config.aiModel. */
+  model: string;
   episodes: Episode[];
   outputPaths: string[];
   message: string;

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/index.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/index.ts
@@ -1,4 +1,5 @@
 import type { VideoJob } from '@abbottland/video-db';
+import { config } from '../../../config';
 import { JobProcessingError } from '../../job-processing-error';
 import type { OperationResult } from '../operation-result';
 import { runSteps } from '../pipeline';
@@ -16,6 +17,7 @@ export const runPawPatrolTitleCardsOperation = async (
     {
       job,
       seasonNumber: job.parameters.seasonNumber,
+      model: job.parameters.model ?? config.aiModel,
       episodes: [],
       outputPaths: [],
       message: '',

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/lib/detect-title-card.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/lib/detect-title-card.ts
@@ -2,8 +2,11 @@ import {
   getAiResponseCache,
   upsertAiResponseCache,
 } from '@abbottland/video-db';
-import { chatCompletion } from '../../../../api/ai/ai-client';
-import { config } from '../../../../config';
+import {
+  chatCompletion,
+  parseJsonResponse,
+  type ChatCompletionRequest,
+} from '../../../../api/ai/ai-client';
 import { db } from '../../../../db';
 
 const SYSTEM_PROMPT =
@@ -36,15 +39,16 @@ export const detectTitleCard = async (
   screenshotPath: string,
   imageBase64: string,
   mimeType: string,
+  model: string,
 ): Promise<TitleCardDetectionResult> => {
-  const cached = await getAiResponseCache(db, screenshotPath, config.aiModel);
+  const cached = await getAiResponseCache(db, screenshotPath, model);
 
   if (cached) {
     return cached.response as TitleCardDetectionResult;
   }
 
-  const content = await chatCompletion({
-    model: config.aiModel,
+  const request: ChatCompletionRequest = {
+    model,
     messages: [
       { role: 'system', content: SYSTEM_PROMPT },
       {
@@ -58,13 +62,14 @@ export const detectTitleCard = async (
         ],
       },
     ],
-  });
+  };
 
-  const result = JSON.parse(content) as TitleCardDetectionResult;
+  const content = await chatCompletion(request);
+  const result = parseJsonResponse<TitleCardDetectionResult>(request, content);
 
   await upsertAiResponseCache(db, {
     screenshotPath,
-    model: config.aiModel,
+    model,
     response: result,
   });
 

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/parameters.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/parameters.ts
@@ -1,5 +1,7 @@
 export type PawPatrolTitleCardsParameters = {
   seasonNumber: number;
+  /** Overrides config.aiModel for this job's title-card detection calls, when set. */
+  model?: string;
 };
 
 export const isPawPatrolTitleCardsParameters = (
@@ -7,4 +9,6 @@ export const isPawPatrolTitleCardsParameters = (
 ): value is PawPatrolTitleCardsParameters =>
   typeof value === 'object' &&
   value !== null &&
-  typeof (value as PawPatrolTitleCardsParameters).seasonNumber === 'number';
+  typeof (value as PawPatrolTitleCardsParameters).seasonNumber === 'number' &&
+  (typeof (value as PawPatrolTitleCardsParameters).model === 'undefined' ||
+    typeof (value as PawPatrolTitleCardsParameters).model === 'string');

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/steps/detect-episode-title-cards.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/steps/detect-episode-title-cards.ts
@@ -58,6 +58,7 @@ export const detectEpisodeTitleCards: Step<PawPatrolTitleCardsContext> = async (
         screenshotPath,
         imageBase64,
         SCREENSHOT_MIME_TYPE,
+        ctx.model,
       );
 
       titleCardDetections.push({

--- a/apps/video-worker/tests/unit/ai-client.unit.test.ts
+++ b/apps/video-worker/tests/unit/ai-client.unit.test.ts
@@ -1,4 +1,4 @@
-import { chatCompletion } from '../../src/api/ai/ai-client';
+import { chatCompletion, parseJsonResponse } from '../../src/api/ai/ai-client';
 
 jest.mock('../../src/config', () => ({
   config: { aiApiUrl: 'http://ai.local:1234' },
@@ -98,5 +98,74 @@ describe('chatCompletion', () => {
     await assertion;
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('parseJsonResponse', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns the parsed JSON on success', () => {
+    const request = {
+      model: 'm',
+      messages: [{ role: 'user' as const, content: 'hi' }],
+    };
+
+    expect(parseJsonResponse(request, '{"found":true}')).toEqual({
+      found: true,
+    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs the prompt and raw response, then rethrows, on malformed JSON', () => {
+    const request = {
+      model: 'm',
+      messages: [
+        { role: 'system' as const, content: 'be terse' },
+        { role: 'user' as const, content: 'describe this image' },
+      ],
+    };
+    const content = '```json\n{"found":true}\n```';
+
+    expect(() => parseJsonResponse(request, content)).toThrow(SyntaxError);
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const logged = consoleErrorSpy.mock.calls[0][0] as string;
+    expect(logged).toContain('m');
+    expect(logged).toContain('be terse');
+    expect(logged).toContain('describe this image');
+    expect(logged).toContain(content);
+  });
+
+  it('summarizes image_url parts instead of dumping the raw base64', () => {
+    const request = {
+      model: 'm',
+      messages: [
+        {
+          role: 'user' as const,
+          content: [
+            { type: 'text' as const, text: 'look at this' },
+            {
+              type: 'image_url' as const,
+              image_url: { url: `data:image/jpeg;base64,${'A'.repeat(500)}` },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(() => parseJsonResponse(request, 'not json')).toThrow(SyntaxError);
+
+    const logged = consoleErrorSpy.mock.calls[0][0] as string;
+    expect(logged).toContain('look at this');
+    expect(logged).toContain('[image omitted');
+    expect(logged).not.toContain('A'.repeat(500));
   });
 });

--- a/apps/video-worker/tests/unit/check-title-card-records.unit.test.ts
+++ b/apps/video-worker/tests/unit/check-title-card-records.unit.test.ts
@@ -14,6 +14,7 @@ const buildContext = (
 ): PawPatrolTitleCardsContext => ({
   job: {} as VideoJob,
   seasonNumber: 3,
+  model: 'test-model',
   episodes: [],
   outputPaths: [],
   message: '',

--- a/apps/video-worker/tests/unit/compute-episode-runtime.unit.test.ts
+++ b/apps/video-worker/tests/unit/compute-episode-runtime.unit.test.ts
@@ -12,6 +12,7 @@ const buildContext = (
 ): PawPatrolTitleCardsContext => ({
   job: {} as VideoJob,
   seasonNumber: 3,
+  model: 'test-model',
   episodes: [],
   outputPaths: [],
   message: '',

--- a/apps/video-worker/tests/unit/detect-episode-title-cards.unit.test.ts
+++ b/apps/video-worker/tests/unit/detect-episode-title-cards.unit.test.ts
@@ -21,6 +21,7 @@ const buildContext = (
 ): PawPatrolTitleCardsContext => ({
   job: {} as VideoJob,
   seasonNumber: 3,
+  model: 'test-model',
   episodes: [],
   outputPaths: [],
   message: '',
@@ -114,6 +115,7 @@ describe('detectEpisodeTitleCards', () => {
       'screenshots/Paw Patrol/Season 3/hash-1/45_480x270.jpg',
       Buffer.from('jpegbytes').toString('base64'),
       'image/jpeg',
+      'test-model',
     );
 
     const screenshotBase64 = Buffer.from('jpegbytes').toString('base64');

--- a/apps/video-worker/tests/unit/detect-title-card.unit.test.ts
+++ b/apps/video-worker/tests/unit/detect-title-card.unit.test.ts
@@ -6,18 +6,17 @@ import { chatCompletion } from '../../src/api/ai/ai-client';
 import { detectTitleCard } from '../../src/worker/operations/paw-patrol-title-cards/lib/detect-title-card';
 
 jest.mock('../../src/api/ai/ai-client', () => ({
+  ...jest.requireActual('../../src/api/ai/ai-client'),
   chatCompletion: jest.fn(),
 }));
 jest.mock('@abbottland/video-db', () => ({
   getAiResponseCache: jest.fn(),
   upsertAiResponseCache: jest.fn(),
 }));
-jest.mock('../../src/config', () => ({
-  config: { aiModel: 'qwen/qwen3-vl-8b-instruct' },
-}));
 jest.mock('../../src/db', () => ({ db: {} }));
 
 const SCREENSHOT_PATH = 'screenshots/Paw Patrol/Season 3/hash-1/45_480x270.jpg';
+const MODEL = 'qwen/qwen3-vl-8b-instruct';
 
 describe('detectTitleCard', () => {
   afterEach(() => {
@@ -37,14 +36,11 @@ describe('detectTitleCard', () => {
       SCREENSHOT_PATH,
       'BASE64DATA',
       'image/jpeg',
+      MODEL,
     );
 
     expect(result).toEqual({ found: true, title: 'Pups Save a Blimp' });
-    expect(getAiResponseCache).toHaveBeenCalledWith(
-      {},
-      SCREENSHOT_PATH,
-      'qwen/qwen3-vl-8b-instruct',
-    );
+    expect(getAiResponseCache).toHaveBeenCalledWith({}, SCREENSHOT_PATH, MODEL);
     expect(chatCompletion).not.toHaveBeenCalled();
     expect(upsertAiResponseCache).not.toHaveBeenCalled();
   });
@@ -59,17 +55,18 @@ describe('detectTitleCard', () => {
       SCREENSHOT_PATH,
       'BASE64DATA',
       'image/jpeg',
+      MODEL,
     );
 
     expect(result).toEqual({ found: false });
     expect(chatCompletion).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'qwen/qwen3-vl-8b-instruct' }),
+      expect.objectContaining({ model: MODEL }),
     );
     expect(upsertAiResponseCache).toHaveBeenCalledWith(
       {},
       {
         screenshotPath: SCREENSHOT_PATH,
-        model: 'qwen/qwen3-vl-8b-instruct',
+        model: MODEL,
         response: { found: false },
       },
     );
@@ -79,7 +76,7 @@ describe('detectTitleCard', () => {
     (getAiResponseCache as jest.Mock).mockResolvedValue(undefined);
     (chatCompletion as jest.Mock).mockResolvedValue('{"found":false}');
 
-    await detectTitleCard(SCREENSHOT_PATH, 'BASE64DATA', 'image/jpeg');
+    await detectTitleCard(SCREENSHOT_PATH, 'BASE64DATA', 'image/jpeg', MODEL);
 
     const request = (chatCompletion as jest.Mock).mock.calls[0][0];
     expect(request.messages[0]).toEqual({
@@ -99,7 +96,7 @@ describe('detectTitleCard', () => {
     (chatCompletion as jest.Mock).mockResolvedValue('not json');
 
     await expect(
-      detectTitleCard(SCREENSHOT_PATH, 'BASE64DATA', 'image/jpeg'),
+      detectTitleCard(SCREENSHOT_PATH, 'BASE64DATA', 'image/jpeg', MODEL),
     ).rejects.toThrow();
     expect(upsertAiResponseCache).not.toHaveBeenCalled();
   });

--- a/apps/video-worker/tests/unit/generate-episode-screenshots.unit.test.ts
+++ b/apps/video-worker/tests/unit/generate-episode-screenshots.unit.test.ts
@@ -24,6 +24,7 @@ const buildContext = (
 ): PawPatrolTitleCardsContext => ({
   job: {} as VideoJob,
   seasonNumber: 3,
+  model: 'test-model',
   episodes: [],
   outputPaths: [],
   message: '',

--- a/apps/video-worker/tests/unit/hash-episode-files.unit.test.ts
+++ b/apps/video-worker/tests/unit/hash-episode-files.unit.test.ts
@@ -12,6 +12,7 @@ const buildContext = (
 ): PawPatrolTitleCardsContext => ({
   job: {} as VideoJob,
   seasonNumber: 3,
+  model: 'test-model',
   episodes: [],
   outputPaths: [],
   message: '',

--- a/apps/video-worker/tests/unit/insert-episode-title-cards.unit.test.ts
+++ b/apps/video-worker/tests/unit/insert-episode-title-cards.unit.test.ts
@@ -14,6 +14,7 @@ const buildContext = (
 ): PawPatrolTitleCardsContext => ({
   job: {} as VideoJob,
   seasonNumber: 3,
+  model: 'test-model',
   episodes: [],
   outputPaths: [],
   message: '',

--- a/apps/video-worker/tests/unit/list-season-files.unit.test.ts
+++ b/apps/video-worker/tests/unit/list-season-files.unit.test.ts
@@ -14,6 +14,7 @@ const buildContext = (
 ): PawPatrolTitleCardsContext => ({
   job: {} as VideoJob,
   seasonNumber: 3,
+  model: 'test-model',
   episodes: [],
   outputPaths: [],
   message: '',

--- a/apps/video-worker/tests/unit/paw-patrol-file-suggestions.unit.test.ts
+++ b/apps/video-worker/tests/unit/paw-patrol-file-suggestions.unit.test.ts
@@ -28,6 +28,7 @@ jest.mock('../../src/api/sonarr/sonarr-client', () => ({
     ]),
 }));
 jest.mock('../../src/api/ai/ai-client', () => ({
+  ...jest.requireActual('../../src/api/ai/ai-client'),
   chatCompletion: jest
     .fn()
     .mockResolvedValue(

--- a/apps/video-worker/tests/unit/paw-patrol-title-cards.unit.test.ts
+++ b/apps/video-worker/tests/unit/paw-patrol-title-cards.unit.test.ts
@@ -14,7 +14,12 @@ jest.mock('child_process', () => ({
   ),
 }));
 jest.mock('../../src/config', () => ({
-  config: { mediaRoot: '/media', ffprobePath: 'ffprobe', ffmpegPath: 'ffmpeg' },
+  config: {
+    mediaRoot: '/media',
+    ffprobePath: 'ffprobe',
+    ffmpegPath: 'ffmpeg',
+    aiModel: 'default-model',
+  },
 }));
 jest.mock('@abbottland/video-db', () => ({
   hashFile: jest.fn().mockResolvedValue('fakehash'),
@@ -25,6 +30,7 @@ jest.mock('@abbottland/video-db', () => ({
 }));
 jest.mock('../../src/db', () => ({ db: {} }));
 jest.mock('../../src/api/ai/ai-client', () => ({
+  ...jest.requireActual('../../src/api/ai/ai-client'),
   chatCompletion: jest.fn().mockResolvedValue('{"found":false}'),
 }));
 

--- a/apps/video-worker/tests/unit/refine-split-point.unit.test.ts
+++ b/apps/video-worker/tests/unit/refine-split-point.unit.test.ts
@@ -40,7 +40,13 @@ describe('refineSplitPoint', () => {
       .mockResolvedValueOnce({ found: true, title: 'x' }) // 44.8
       .mockResolvedValueOnce({ found: false }); // 44.7
 
-    const result = await refineSplitPoint(3, 'hash-1', '/media/e18-19.mp4', 45);
+    const result = await refineSplitPoint(
+      3,
+      'hash-1',
+      '/media/e18-19.mp4',
+      45,
+      'test-model',
+    );
 
     expect(result).toBe(44.8);
     expect(execFile).toHaveBeenCalledTimes(3);
@@ -55,13 +61,20 @@ describe('refineSplitPoint', () => {
       'screenshots/Paw Patrol/Season 3/hash-1/44.7_refine_480x270.jpg',
       'aW1n',
       'image/jpeg',
+      'test-model',
     );
   });
 
   it('returns the coarse timestamp unchanged when the card is not found even one step back', async () => {
     (detectTitleCard as jest.Mock).mockResolvedValue({ found: false });
 
-    const result = await refineSplitPoint(3, 'hash-1', '/media/e18-19.mp4', 45);
+    const result = await refineSplitPoint(
+      3,
+      'hash-1',
+      '/media/e18-19.mp4',
+      45,
+      'test-model',
+    );
 
     expect(result).toBe(45);
     expect(execFile).toHaveBeenCalledTimes(1);
@@ -73,7 +86,13 @@ describe('refineSplitPoint', () => {
       title: 'x',
     });
 
-    const result = await refineSplitPoint(3, 'hash-1', '/media/e18-19.mp4', 45);
+    const result = await refineSplitPoint(
+      3,
+      'hash-1',
+      '/media/e18-19.mp4',
+      45,
+      'test-model',
+    );
 
     expect(result).toBe(42.5);
     expect(execFile).toHaveBeenCalledTimes(25);
@@ -83,7 +102,7 @@ describe('refineSplitPoint', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
     (detectTitleCard as jest.Mock).mockResolvedValueOnce({ found: false });
 
-    await refineSplitPoint(3, 'hash-1', '/media/e18-19.mp4', 45);
+    await refineSplitPoint(3, 'hash-1', '/media/e18-19.mp4', 45, 'test-model');
 
     expect(execFile).not.toHaveBeenCalled();
   });
@@ -99,6 +118,7 @@ describe('refineSplitPoint', () => {
       'hash-1',
       '/media/e18-19.mp4',
       0.1,
+      'test-model',
     );
 
     expect(result).toBe(0);

--- a/apps/video-worker/tests/unit/suggest-double-episode.unit.test.ts
+++ b/apps/video-worker/tests/unit/suggest-double-episode.unit.test.ts
@@ -2,6 +2,7 @@ import { chatCompletion } from '../../src/api/ai/ai-client';
 import { suggestDoubleEpisode } from '../../src/worker/operations/paw-patrol-file-suggestions/lib/suggest-double-episode';
 
 jest.mock('../../src/api/ai/ai-client', () => ({
+  ...jest.requireActual('../../src/api/ai/ai-client'),
   chatCompletion: jest.fn(),
 }));
 

--- a/apps/video-worker/tests/unit/suggest-filenames.unit.test.ts
+++ b/apps/video-worker/tests/unit/suggest-filenames.unit.test.ts
@@ -255,6 +255,7 @@ describe('suggestFilenames', () => {
         'hash-1',
         '/media/random-name.mp4',
         660,
+        context.model,
       );
       expect(suggestSingleEpisode).not.toHaveBeenCalled();
     });

--- a/apps/video-worker/tests/unit/suggest-single-episode.unit.test.ts
+++ b/apps/video-worker/tests/unit/suggest-single-episode.unit.test.ts
@@ -2,6 +2,7 @@ import { chatCompletion } from '../../src/api/ai/ai-client';
 import { suggestSingleEpisode } from '../../src/worker/operations/paw-patrol-file-suggestions/lib/suggest-single-episode';
 
 jest.mock('../../src/api/ai/ai-client', () => ({
+  ...jest.requireActual('../../src/api/ai/ai-client'),
   chatCompletion: jest.fn(),
 }));
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "turbo run clean",
     "dev": "turbo run dev",
     "dev:ui": "turbo run dev --filter=@abbottland/blog --filter=@abbottland/fui-components --filter=@abbottland/diagram-maker --filter=@abbottland/home-hud",
+    "dev:video": "turbo run dev --filter=@abbottland/home-hud --filter=@abbottland/video-api --filter=@abbottland/video-worker",
     "dev:deps": "turbo run dev:deps",
     "dev:deps:down": "turbo run dev:deps:down",
     "format:check": "prettier . --check",

--- a/packages/video-db/src/index.ts
+++ b/packages/video-db/src/index.ts
@@ -60,6 +60,7 @@ export {
   listFileRenames,
   listPendingFileRenames,
   deleteFileRenamesBySeason,
+  deleteFileRenameById,
 } from './queries/file-renames';
 export type {
   UpsertFileRenameInput,

--- a/packages/video-db/src/queries/file-renames.ts
+++ b/packages/video-db/src/queries/file-renames.ts
@@ -75,6 +75,23 @@ export const updateFileRenameStatus = async (
   return fileRename;
 };
 
+/**
+ * Deletes a single file_renames row by id, returning it (or undefined if no
+ * row matched). Row-level rather than season-scoped so a bad suggestion can
+ * be removed on its own without disturbing correctly suggested siblings.
+ */
+export const deleteFileRenameById = async (
+  db: Database,
+  id: string,
+): Promise<FileRename | undefined> => {
+  const [fileRename] = await db
+    .delete(fileRenames)
+    .where(eq(fileRenames.id, id))
+    .returning();
+
+  return fileRename;
+};
+
 export type ListFileRenamesOptions = {
   fileHash?: string;
   status?: FileRenameStatus;


### PR DESCRIPTION
## Summary

Adds the video-processing subsystem to the monorepo and builds the home-hud UI on top of it. This branch has been the long-running home for that work — 463 commits, 387 files touched.

- **apps/video-api** — Express API queuing/tracking video-processing jobs (Postgres-backed via video-db)
- **apps/video-worker** — polls video-api for jobs, drives the Paw Patrol title-card detection, file-suggestion, and apply-rename pipelines against a local AI server
- **packages/video-db** — Drizzle ORM schema, migrations, query helpers shared by video-api/video-worker
- **apps/home-hud** — Jobs, Title Cards, and File Renames pages, plus a new landing page with system-status and per-page summary panels

Most recent work on this branch (this session):
- File Renames page: status filter, per-row delete
- `pnpm dev:video` turbo script (home-hud + video-api + video-worker together)
- Per-job AI model override for title-cards jobs; diagnostic prompt/response logging on malformed AI JSON responses
- home-hud landing page: system-status strip + linked summary panels for Jobs/Title Cards/File Renames

Given the size, recommend reviewing by top-level area (video-api / video-worker / video-db / home-hud) rather than commit-by-commit.

## Test plan
- [ ] `pnpm lint` / `pnpm test:unit` pass across video-api, video-worker, video-db, home-hud (verified locally this session for the latest changes)
- [ ] Smoke the home-hud pages (Jobs, Title Cards, File Renames, new landing page) against a running video-api/video-worker
- [ ] Confirm DB migrations apply cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wZq5hgLJN1vVfYR4MjQc8