### PR TITLE
fix(video-worker,express): job status accuracy, AI JSON parsing, log noise

### DIFF
--- a/apps/video-worker/src/api/ai/ai-client.ts
+++ b/apps/video-worker/src/api/ai/ai-client.ts
@@ -129,20 +129,32 @@ const describeMessages = (messages: ChatMessage[]): string =>
     )
     .join('\n\n');
 
+const CODE_FENCE_PATTERN = /^```(?:json)?\s*([\s\S]*?)\s*```$/;
+
 /**
- * Parses an AI response as JSON, dumping the full prompt and raw response to
- * the logs before rethrowing on failure — the model occasionally wraps its
- * JSON in a markdown code fence or adds stray text despite being told not
- * to, and the bare SyntaxError from JSON.parse alone doesn't say what it
- * actually sent back, making that failure mode otherwise undiagnosable
- * after the fact.
+ * Strips a wrapping markdown code fence (```json ... ``` or ``` ... ```),
+ * if present. Models are told to respond with JSON only but routinely wrap
+ * it in a fence anyway.
+ */
+const stripCodeFence = (content: string): string => {
+  const match = content.trim().match(CODE_FENCE_PATTERN);
+  return match ? match[1] : content;
+};
+
+/**
+ * Parses an AI response as JSON, tolerating a wrapping markdown code fence.
+ * Dumps the full prompt and raw response to the logs before rethrowing on
+ * failure — the model occasionally adds stray text outside a fence despite
+ * being told not to, and the bare SyntaxError from JSON.parse alone doesn't
+ * say what it actually sent back, making that failure mode otherwise
+ * undiagnosable after the fact.
  */
 export const parseJsonResponse = <T>(
   request: ChatCompletionRequest,
   content: string,
 ): T => {
   try {
-    return JSON.parse(content) as T;
+    return JSON.parse(stripCodeFence(content)) as T;
   } catch (err) {
     console.error(
       `❌ AI response was not valid JSON (model=${request.model})\n${describeMessages(request.messages)}\n--- response ---\n${content}`,

--- a/apps/video-worker/src/worker/operations/paw-patrol-apply-file-renames/index.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-apply-file-renames/index.ts
@@ -27,11 +27,13 @@ const summarizeSkips = (skipped: SkippedRow[]): string => {
  * chain could plausibly span season directories.
  *
  * One row failing (an unresolvable collision, a cycle, a missing/mismatched
- * source, an ffmpeg error) never fails the whole job — it's recorded in
- * ctx.skipped, left `pending` in the DB, and the loop moves on. Every row
- * that does apply is marked so immediately after its filesystem mutation
- * succeeds, not batched at the end, so a mid-run crash leaves a resumable
- * state (already-applied rows stay applied, the rest are picked up next run).
+ * source, an ffmpeg error) never fails the whole job on its own — it's
+ * recorded in ctx.skipped, left `pending` in the DB, and the loop moves on.
+ * Every row that does apply is marked so immediately after its filesystem
+ * mutation succeeds, not batched at the end, so a mid-run crash leaves a
+ * resumable state (already-applied rows stay applied, the rest are picked up
+ * next run). If every row errored (e.g. a systemic permission/mount problem),
+ * the job throws instead of reporting a misleading "completed" — see below.
  */
 export const runPawPatrolApplyFileRenamesOperation = async (
   job: VideoJob,
@@ -79,6 +81,17 @@ export const runPawPatrolApplyFileRenamesOperation = async (
   const skipSummary = ctx.skipped.length
     ? ` (${summarizeSkips(ctx.skipped)})`
     : '';
+
+  if (
+    rows.length > 0 &&
+    applied === 0 &&
+    ctx.skipped.length > 0 &&
+    ctx.skipped.every((skip) => skip.reason === 'error')
+  ) {
+    throw new JobProcessingError(
+      `all ${ctx.skipped.length} row(s) errored, 0 applied: ${summarizeSkips(ctx.skipped)}`,
+    );
+  }
 
   return {
     outputPaths: ctx.outputPaths,

--- a/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/suggest-double-episode.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/suggest-double-episode.ts
@@ -16,7 +16,7 @@ Matching rules:
 - Preserve file order: "episodes[0]" must correspond to the FIRST title card given (the earlier segment), and "episodes[1]" to the SECOND.
 - If either segment's text is empty, garbled, or doesn't clearly correspond to exactly one entry in the official list, you do not have enough evidence for a confident match on the whole file — do not guess.
 
-Respond with valid JSON only, no markdown, no explanation, no other text.`;
+Respond with valid JSON only: no markdown, no code fences, no explanation, no other text.`;
 
 const buildUserPrompt = (
   filename: string,

--- a/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/suggest-single-episode.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-file-suggestions/lib/suggest-single-episode.ts
@@ -12,7 +12,7 @@ Matching rules:
 - The detected text must correspond to the SAME episode, not just a similar-sounding or thematically related one. "Pups Save a Goldfish" and "Pups Save a Goldrush" are different episodes even though they look alike.
 - If the detected text is empty, garbled, or doesn't clearly correspond to exactly one entry in the official list, you do not have enough evidence — do not guess.
 
-Respond with valid JSON only, no markdown, no explanation, no other text.`;
+Respond with valid JSON only: no markdown, no code fences, no explanation, no other text.`;
 
 const buildUserPrompt = (
   filename: string,

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/context.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/context.ts
@@ -14,5 +14,4 @@ export type PawPatrolTitleCardsContext = {
   model: string;
   episodes: Episode[];
   outputPaths: string[];
-  message: string;
 };

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/index.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/index.ts
@@ -3,8 +3,49 @@ import { config } from '../../../config';
 import { JobProcessingError } from '../../job-processing-error';
 import type { OperationResult } from '../operation-result';
 import { runSteps } from '../pipeline';
+import type { PawPatrolTitleCardsContext } from './context';
+import type { Episode } from './episode';
 import { isPawPatrolTitleCardsParameters } from './parameters';
 import { steps } from './steps';
+
+/**
+ * An episode only gets `titleCardDetections` from detect-episode-title-cards
+ * (and downstream `titleCards` from insert-episode-title-cards) when it
+ * arrived at this run with no existing title_cards record — episodes that
+ * already had one pass through every step unchanged. That's the only signal
+ * available for "processed this run" vs. "already done", so it doubles as
+ * the summary's episode-level split.
+ */
+const wasProcessedThisRun = (episode: Episode): boolean =>
+  episode.titleCardDetections !== undefined;
+
+const summarizeResult = (context: PawPatrolTitleCardsContext): string => {
+  const processed = context.episodes.filter(wasProcessedThisRun);
+  const alreadyDone = context.episodes.length - processed.length;
+  const titleCardsWritten = processed.reduce(
+    (sum, episode) => sum + (episode.titleCards?.length ?? 0),
+    0,
+  );
+  const noTitleCardFound = processed.filter(
+    (episode) => (episode.titleCards?.length ?? 0) === 0,
+  ).length;
+
+  const parts = [
+    `processed ${processed.length} episode(s)`,
+    `${context.outputPaths.length} screenshot(s) generated`,
+    `${titleCardsWritten} title card record(s) written`,
+  ];
+
+  if (alreadyDone > 0) {
+    parts.push(`${alreadyDone} already had title cards`);
+  }
+
+  if (noTitleCardFound > 0) {
+    parts.push(`${noTitleCardFound} with no title card detected`);
+  }
+
+  return parts.join(', ');
+};
 
 export const runPawPatrolTitleCardsOperation = async (
   job: VideoJob,
@@ -20,10 +61,12 @@ export const runPawPatrolTitleCardsOperation = async (
       model: job.parameters.model ?? config.aiModel,
       episodes: [],
       outputPaths: [],
-      message: '',
     },
     steps,
   );
 
-  return { outputPaths: context.outputPaths, message: context.message };
+  return {
+    outputPaths: context.outputPaths,
+    message: summarizeResult(context),
+  };
 };

--- a/apps/video-worker/src/worker/operations/paw-patrol-title-cards/lib/detect-title-card.ts
+++ b/apps/video-worker/src/worker/operations/paw-patrol-title-cards/lib/detect-title-card.ts
@@ -10,7 +10,7 @@ import {
 import { db } from '../../../../db';
 
 const SYSTEM_PROMPT =
-  'You extract text from images. Respond with valid JSON only, no other text.';
+  'You extract text from images. Respond with valid JSON only: no markdown, no code fences, no explanation, no other text.';
 
 const USER_PROMPT =
   'Look at this image. If it shows a Paw Patrol episode title (large stylized text on screen), return {"found": true, "title": "the exact title text"}. If no title is visible, return {"found": false}.';

--- a/apps/video-worker/tests/integration/poll-loop.integration.test.ts
+++ b/apps/video-worker/tests/integration/poll-loop.integration.test.ts
@@ -61,7 +61,9 @@ describe('worker job processing', () => {
     expect(updated?.outputPaths?.[0]).toMatch(
       /^screenshots\/Paw Patrol\/Season 3\/[0-9a-f]{64}\/31_480x270\.jpg$/,
     );
-    expect(updated?.message).toBe('');
+    expect(updated?.message).toBe(
+      'processed 1 episode(s), 15 screenshot(s) generated, 0 title card record(s) written, 1 with no title card detected',
+    );
   }, 20000);
 
   it('marks a job with an unsupported operation as failed', async () => {

--- a/apps/video-worker/tests/unit/ai-client.unit.test.ts
+++ b/apps/video-worker/tests/unit/ai-client.unit.test.ts
@@ -124,6 +124,29 @@ describe('parseJsonResponse', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it('strips a ```json code fence before parsing', () => {
+    const request = {
+      model: 'm',
+      messages: [{ role: 'user' as const, content: 'hi' }],
+    };
+
+    expect(parseJsonResponse(request, '```json\n{"found":true}\n```')).toEqual({
+      found: true,
+    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('strips a bare ``` code fence before parsing', () => {
+    const request = {
+      model: 'm',
+      messages: [{ role: 'user' as const, content: 'hi' }],
+    };
+
+    expect(parseJsonResponse(request, '```\n{"found":true}\n```')).toEqual({
+      found: true,
+    });
+  });
+
   it('logs the prompt and raw response, then rethrows, on malformed JSON', () => {
     const request = {
       model: 'm',
@@ -132,7 +155,7 @@ describe('parseJsonResponse', () => {
         { role: 'user' as const, content: 'describe this image' },
       ],
     };
-    const content = '```json\n{"found":true}\n```';
+    const content = 'sure, here you go: {"found":true}';
 
     expect(() => parseJsonResponse(request, content)).toThrow(SyntaxError);
 

--- a/apps/video-worker/tests/unit/apply-file-renames.unit.test.ts
+++ b/apps/video-worker/tests/unit/apply-file-renames.unit.test.ts
@@ -453,6 +453,38 @@ describe('runPawPatrolApplyFileRenamesOperation', () => {
     );
     expect(result.message).toBe('applied 1 rename(s), skipped 1 (1 error)');
   });
+
+  it('throws when every row errors (e.g. a systemic permission problem)', async () => {
+    const rowA = buildFileRename({
+      fileHash: 'hash-a',
+      originalFilePath: 'Paw Patrol/Season 3/a.mp4',
+      suggestedFilePath: 'Paw Patrol/Season 3/a-target.mp4',
+    });
+    const rowB = buildFileRename({
+      fileHash: 'hash-b',
+      originalFilePath: 'Paw Patrol/Season 3/b.mp4',
+      suggestedFilePath: 'Paw Patrol/Season 3/b-target.mp4',
+    });
+    (listPendingFileRenames as jest.Mock).mockResolvedValue([rowA, rowB]);
+
+    existingPaths.add(absPath(rowA.originalFilePath));
+    existingPaths.add(absPath(rowB.originalFilePath));
+    mockHashMap({
+      [absPath(rowA.originalFilePath)]: 'hash-a',
+      [absPath(rowB.originalFilePath)]: 'hash-b',
+    });
+    (fs.renameSync as jest.Mock).mockImplementation(() => {
+      throw Object.assign(new Error('EACCES: permission denied'), {
+        code: 'EACCES',
+      });
+    });
+
+    await expect(
+      runPawPatrolApplyFileRenamesOperation({ parameters: {} } as VideoJob),
+    ).rejects.toThrow(/all 2 row\(s\) errored, 0 applied/);
+
+    expect(updateFileRenameStatus).not.toHaveBeenCalled();
+  });
 });
 
 function mockHashMap(map: Record<string, string>) {

--- a/apps/video-worker/tests/unit/check-title-card-records.unit.test.ts
+++ b/apps/video-worker/tests/unit/check-title-card-records.unit.test.ts
@@ -17,7 +17,6 @@ const buildContext = (
   model: 'test-model',
   episodes: [],
   outputPaths: [],
-  message: '',
   ...overrides,
 });
 

--- a/apps/video-worker/tests/unit/compute-episode-runtime.unit.test.ts
+++ b/apps/video-worker/tests/unit/compute-episode-runtime.unit.test.ts
@@ -15,7 +15,6 @@ const buildContext = (
   model: 'test-model',
   episodes: [],
   outputPaths: [],
-  message: '',
   ...overrides,
 });
 

--- a/apps/video-worker/tests/unit/detect-episode-title-cards.unit.test.ts
+++ b/apps/video-worker/tests/unit/detect-episode-title-cards.unit.test.ts
@@ -24,7 +24,6 @@ const buildContext = (
   model: 'test-model',
   episodes: [],
   outputPaths: [],
-  message: '',
   ...overrides,
 });
 

--- a/apps/video-worker/tests/unit/generate-episode-screenshots.unit.test.ts
+++ b/apps/video-worker/tests/unit/generate-episode-screenshots.unit.test.ts
@@ -27,7 +27,6 @@ const buildContext = (
   model: 'test-model',
   episodes: [],
   outputPaths: [],
-  message: '',
   ...overrides,
 });
 

--- a/apps/video-worker/tests/unit/hash-episode-files.unit.test.ts
+++ b/apps/video-worker/tests/unit/hash-episode-files.unit.test.ts
@@ -15,7 +15,6 @@ const buildContext = (
   model: 'test-model',
   episodes: [],
   outputPaths: [],
-  message: '',
   ...overrides,
 });
 

--- a/apps/video-worker/tests/unit/insert-episode-title-cards.unit.test.ts
+++ b/apps/video-worker/tests/unit/insert-episode-title-cards.unit.test.ts
@@ -17,7 +17,6 @@ const buildContext = (
   model: 'test-model',
   episodes: [],
   outputPaths: [],
-  message: '',
   ...overrides,
 });
 

--- a/apps/video-worker/tests/unit/list-season-files.unit.test.ts
+++ b/apps/video-worker/tests/unit/list-season-files.unit.test.ts
@@ -17,7 +17,6 @@ const buildContext = (
   model: 'test-model',
   episodes: [],
   outputPaths: [],
-  message: '',
   ...overrides,
 });
 

--- a/apps/video-worker/tests/unit/paw-patrol-title-cards.unit.test.ts
+++ b/apps/video-worker/tests/unit/paw-patrol-title-cards.unit.test.ts
@@ -90,10 +90,46 @@ describe('runPawPatrolTitleCardsOperation', () => {
 
     const result = await runPawPatrolTitleCardsOperation(job);
 
-    expect(result.message).toBe('');
+    expect(result.message).toBe(
+      'processed 1 episode(s), 15 screenshot(s) generated, 0 title card record(s) written, 1 with no title card detected',
+    );
     expect(result.outputPaths).toHaveLength(15);
     expect(result.outputPaths[0]).toBe(
       'screenshots/Paw Patrol/Season 3/fakehash/31_480x270.jpg',
+    );
+  });
+
+  it('summarizes a mix of already-done and newly-processed episodes', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
+    (fs.readdirSync as jest.Mock).mockReturnValue([
+      direntFor('Paw Patrol - S03E01 - Pups Save a Blimp.mp4', true),
+      direntFor('Paw Patrol - S03E02 - Pups Save a Train.mp4', true),
+    ]);
+    (fs.mkdirSync as jest.Mock).mockReturnValue(undefined);
+    (fs.readFileSync as jest.Mock).mockReturnValue(Buffer.from('jpegbytes'));
+
+    const { hashFile, listTitleCards } = jest.requireMock(
+      '@abbottland/video-db',
+    ) as {
+      hashFile: jest.Mock;
+      listTitleCards: jest.Mock;
+    };
+    hashFile.mockImplementation(async (absPath: string) =>
+      absPath.includes('E01') ? 'hash-done' : 'hash-new',
+    );
+    listTitleCards.mockImplementation(async (_db: unknown, { fileHash }) =>
+      fileHash === 'hash-done'
+        ? [{ id: 't1', fileHash: 'hash-done', title: 'existing' }]
+        : [],
+    );
+
+    const job = buildJob();
+
+    const result = await runPawPatrolTitleCardsOperation(job);
+
+    expect(result.message).toBe(
+      'processed 1 episode(s), 15 screenshot(s) generated, 0 title card record(s) written, 1 already had title cards, 1 with no title card detected',
     );
   });
 });

--- a/packages/express/src/middleware/base-server-middleware/base-server-middleware.integration.test.ts
+++ b/packages/express/src/middleware/base-server-middleware/base-server-middleware.integration.test.ts
@@ -109,6 +109,38 @@ describe('Base Server Middleware Integration Tests', () => {
 
       expect(response.body).toEqual({ logged: true });
     });
+
+    it('should not log probe/scrape endpoints', async () => {
+      app.get('/readyz', (_, res) => res.json({ ready: true }));
+      app.get('/healthz', (_, res) => res.json({ ok: true }));
+      app.get('/metrics', (_, res) => res.send('# metrics'));
+
+      const writeSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      await request(app).get('/readyz').expect(200);
+      await request(app).get('/healthz').expect(200);
+      await request(app).get('/metrics').expect(200);
+
+      expect(writeSpy).not.toHaveBeenCalled();
+
+      writeSpy.mockRestore();
+    });
+
+    it('should still log other endpoints', async () => {
+      app.get('/test-still-logged', (_, res) => res.json({ ok: true }));
+
+      const writeSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      await request(app).get('/test-still-logged').expect(200);
+
+      expect(writeSpy).toHaveBeenCalled();
+
+      writeSpy.mockRestore();
+    });
   });
 
   describe('Middleware Order and Integration', () => {

--- a/packages/express/src/middleware/base-server-middleware/base-server-middleware.ts
+++ b/packages/express/src/middleware/base-server-middleware/base-server-middleware.ts
@@ -1,12 +1,19 @@
-import { Express } from 'express';
+import { Express, Request } from 'express';
 import morgan from 'morgan';
 import cors from 'cors';
 import { json, urlencoded } from 'body-parser';
 
+/** Polled on an interval by k8s probes/Prometheus, not real traffic — logging them just buries everything else. */
+const UNLOGGED_PATHS = new Set(['/readyz', '/healthz', '/metrics']);
+
 export const configureBaseServerMiddleware = (app: Express) => {
   app
     .disable('x-powered-by')
-    .use(morgan('dev'))
+    .use(
+      morgan('dev', {
+        skip: (req: Request) => UNLOGGED_PATHS.has(req.path),
+      }),
+    )
     .use(urlencoded({ extended: true }))
     .use(json())
     .use(cors());


### PR DESCRIPTION
## Summary
- `paw_patrol_apply_file_renames`: job now fails instead of reporting false "completed" when every row errors (e.g. a permission mismatch) — was silently swallowing per-row errors and always returning normally
- `parseJsonResponse`: strips a wrapping markdown code fence before parsing, since local AI models (e.g. gemma-4-e4b) routinely wrap JSON responses in ` ```json ` despite being told not to; also tightened all three AI system prompts to explicitly say "no code fences"
- `paw_patrol_title_cards`: job result message now reports real aggregate stats (episodes processed, screenshots generated, title cards written, etc.) instead of an always-empty string — a dead `context.message` field was never written by any pipeline step
- Shared Express middleware: `morgan` now skips `/readyz`, `/healthz`, `/metrics` — these are polled on an interval by k8s probes/Prometheus and were burying real request logs across every server app (video-api, video-worker, gluetun-sync, pi-led-api, harbor-cleanup)

## Test plan
- [x] `apps/video-worker` unit suite passes (141 tests)
- [x] `packages/express` unit + integration suites pass (9 + 29 tests)
- [x] Verified in prod cluster via kubectl: confirmed root cause (UID/permission mismatch on `/media` PVC) and re-ran affected jobs after fixing volume perms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wZq5hgLJN1vVfYR4MjQc8