### PR TITLE
fix(title-cards): filter by season server-side

### DIFF
--- a/apps/home-hud/src/app/title-cards/TitleCardsClient.tsx
+++ b/apps/home-hud/src/app/title-cards/TitleCardsClient.tsx
@@ -35,12 +35,6 @@ const SEASON_OPTIONS = Array.from(
   (_, i) => FIRST_SEASON + i,
 );
 
-/** Pulls the season number out of a `<Show>/Season <N>/<file>` filePath. */
-function extractSeasonNumber(filePath: string): number | null {
-  const match = filePath.match(/Season (\d+)/);
-  return match ? Number(match[1]) : null;
-}
-
 // Fixed locale/timeZone so server and client render identical text — a
 // locale-dependent format (e.g. toLocaleString()) mismatches across the
 // SSR/hydration boundary whenever the server and browser timezones differ.
@@ -56,24 +50,21 @@ function formatDate(iso: string): string {
 
 interface TitleCardsClientProps {
   titleCards: TitleCard[] | null;
+  selectedSeason: number | null;
 }
 
-export function TitleCardsClient({ titleCards }: TitleCardsClientProps) {
+export function TitleCardsClient({
+  titleCards,
+  selectedSeason,
+}: TitleCardsClientProps) {
   const router = useRouter();
   const [page, setPage] = useState(1);
-  const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
   const [seasonMenuOpen, setSeasonMenuOpen] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  const filteredTitleCards = titleCards?.filter(
-    (titleCard) =>
-      selectedSeason === null ||
-      extractSeasonNumber(titleCard.filePath) === selectedSeason,
-  );
-
-  const sortedTitleCards = filteredTitleCards
+  const sortedTitleCards = titleCards
     ?.slice()
     .sort((a, b) => a.filePath.localeCompare(b.filePath));
 
@@ -86,7 +77,9 @@ export function TitleCardsClient({ titleCards }: TitleCardsClientProps) {
   );
 
   function selectSeason(season: number | null) {
-    setSelectedSeason(season);
+    router.push(
+      season === null ? '/title-cards' : `/title-cards?season=${season}`,
+    );
     setPage(1);
   }
 
@@ -147,16 +140,14 @@ export function TitleCardsClient({ titleCards }: TitleCardsClientProps) {
             Failed to load title cards from video-api.
           </Typography>
         )}
-        {titleCards?.length === 0 && (
+        {titleCards?.length === 0 && selectedSeason === null && (
           <Typography variant="body1">No title cards yet.</Typography>
         )}
-        {titleCards &&
-          titleCards.length > 0 &&
-          filteredTitleCards?.length === 0 && (
-            <Typography variant="body1">
-              No title cards for Season {selectedSeason}.
-            </Typography>
-          )}
+        {titleCards?.length === 0 && selectedSeason !== null && (
+          <Typography variant="body1">
+            No title cards for Season {selectedSeason}.
+          </Typography>
+        )}
         {pageTitleCards && pageTitleCards.length > 0 && (
           <>
             <ScrollableTable className="mb-0">

--- a/apps/home-hud/src/app/title-cards/lib/video-api.ts
+++ b/apps/home-hud/src/app/title-cards/lib/video-api.ts
@@ -12,8 +12,13 @@ export interface TitleCard {
   createdAt: string;
 }
 
-export async function getTitleCards(): Promise<TitleCard[]> {
-  const res = await fetch(`${VIDEO_API_URL}/title-cards`, {
+export async function getTitleCards(season?: number): Promise<TitleCard[]> {
+  const url = new URL(`${VIDEO_API_URL}/title-cards`);
+  if (season !== undefined) {
+    url.searchParams.set('season', String(season));
+  }
+
+  const res = await fetch(url, {
     cache: 'no-store',
   });
 

--- a/apps/home-hud/src/app/title-cards/page.tsx
+++ b/apps/home-hud/src/app/title-cards/page.tsx
@@ -1,14 +1,23 @@
 import { TitleCardsClient } from './TitleCardsClient';
 import { getTitleCards } from './lib/video-api';
 
-export default async function TitleCardsPage() {
+interface TitleCardsPageProps {
+  searchParams: Promise<{ season?: string }>;
+}
+
+export default async function TitleCardsPage({
+  searchParams,
+}: TitleCardsPageProps) {
+  const { season: seasonParam } = await searchParams;
+  const season = seasonParam ? Number(seasonParam) : null;
+
   let titleCards = null;
 
   try {
-    titleCards = await getTitleCards();
+    titleCards = await getTitleCards(season ?? undefined);
   } catch (err) {
     console.error('Failed to load title cards from video-api:', err);
   }
 
-  return <TitleCardsClient titleCards={titleCards} />;
+  return <TitleCardsClient titleCards={titleCards} selectedSeason={season} />;
 }

--- a/apps/video-api/src/controllers/title-cards.ts
+++ b/apps/video-api/src/controllers/title-cards.ts
@@ -8,10 +8,10 @@ import type { ListTitleCardsQuery } from '../schemas/title-cards';
 
 export const listTitleCards = async (req: Request, res: Response) => {
   // req.query is already validated/typed by the validateQuery(listTitleCardsQuerySchema) middleware.
-  const { fileHash } = req.query as ListTitleCardsQuery;
+  const { fileHash, season } = req.query as ListTitleCardsQuery;
 
   try {
-    const titleCards = await listTitleCardsQuery(db, { fileHash });
+    const titleCards = await listTitleCardsQuery(db, { fileHash, season });
 
     res.status(200).json({ titleCards });
   } catch (err) {

--- a/apps/video-api/src/schemas/title-cards.ts
+++ b/apps/video-api/src/schemas/title-cards.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const listTitleCardsQuerySchema = z.object({
   fileHash: z.string().optional(),
+  season: z.coerce.number().int().positive().optional(),
 });
 
 export type ListTitleCardsQuery = z.infer<typeof listTitleCardsQuerySchema>;

--- a/apps/video-api/tests/unit/title-cards.unit.test.ts
+++ b/apps/video-api/tests/unit/title-cards.unit.test.ts
@@ -45,7 +45,32 @@ describe('GET /title-cards', () => {
 
     expect(videoDb.listTitleCards).toHaveBeenCalledWith(undefined, {
       fileHash: 'hash-1',
+      season: undefined,
     });
+  });
+
+  it('passes a valid season through to listTitleCards', async () => {
+    (videoDb.listTitleCards as jest.Mock).mockResolvedValue([]);
+
+    await supertest(createServer())
+      .get('/title-cards')
+      .query({ season: '4' })
+      .expect(200);
+
+    expect(videoDb.listTitleCards).toHaveBeenCalledWith(undefined, {
+      fileHash: undefined,
+      season: 4,
+    });
+  });
+
+  it('rejects a non-numeric season', async () => {
+    const res = await supertest(createServer())
+      .get('/title-cards')
+      .query({ season: 'bogus' })
+      .expect(400);
+
+    expect(res.body.message).toBe('Invalid query parameters');
+    expect(videoDb.listTitleCards).not.toHaveBeenCalled();
   });
 
   it('logs the error and returns a generic message when listing fails', async () => {

--- a/packages/video-db/src/queries/title-cards.ts
+++ b/packages/video-db/src/queries/title-cards.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, like } from 'drizzle-orm';
 import type { Database } from '../client';
 import {
   titleCards,
@@ -78,20 +78,34 @@ export const deleteTitleCardById = async (
 
 export type ListTitleCardsOptions = {
   fileHash?: string;
+  season?: number;
 };
 
 const LIST_TITLE_CARDS_LIMIT = 100;
+
+/** Matches a file_path with `Season <N>` as its own path segment — same convention as seasonDirectoryRelPath in video-worker, e.g. "media/tv_shows/Paw Patrol/Season 4/...". The trailing slash keeps "Season 4" from also matching "Season 40". */
+const seasonPathPattern = (season: number): string => `%/Season ${season}/%`;
 
 export const listTitleCards = async (
   db: Database,
   options: ListTitleCardsOptions = {},
 ): Promise<TitleCard[]> => {
+  const conditions = [];
+
+  if (options.fileHash) {
+    conditions.push(eq(titleCards.fileHash, options.fileHash));
+  }
+
+  if (options.season !== undefined) {
+    conditions.push(
+      like(titleCards.filePath, seasonPathPattern(options.season)),
+    );
+  }
+
   return db
     .select()
     .from(titleCards)
-    .where(
-      options.fileHash ? eq(titleCards.fileHash, options.fileHash) : undefined,
-    )
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
     .orderBy(titleCards.timestampSeconds)
     .limit(LIST_TITLE_CARDS_LIMIT);
 };


### PR DESCRIPTION
## Summary
- `title-cards` page in home-hud showed only 1 record for Season 4 despite 38 existing — root cause: `listTitleCards` orders by `timestamp_seconds` with a hard `LIMIT 100`, and video-api's `GET /title-cards` (no season filter) reused that query for the unfiltered "list everything" case. Home-hud fetched the full (truncated) list and filtered client-side, so most of Season 4 (timestamps 41-59s) never survived the cutoff.
- Added a `season` query param through `video-api` → `listTitleCards` (`packages/video-db`), filtering `file_path` via `LIKE '%/Season N/%'` in SQL.
- home-hud now drives the season filter through the URL (`?season=N`) so the server component fetches an already-filtered set instead of relying on the capped default list.
- Verified against the real production DB directly: season 4 now returns 38 rows (was 1 via the old unfiltered+client-filter path), season 3 returns 47.

## Test plan
- [x] `pnpm lint` / `pnpm typecheck` for `@abbottland/video-db`, `@abbottland/video-api`, `@abbottland/home-hud`
- [x] `pnpm test:unit` for `@abbottland/video-db` and `@abbottland/video-api` (added 2 new tests for the `season` param)
- [x] Verified new query against production Postgres directly (season 4 → 38 rows, season 3 → 47 rows)
- [ ] Manual check in home-hud UI once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTf2ftRRhpfbjFkKU3SrpG